### PR TITLE
♻️ refactor: WebTestClient를 사용하여 테스트하도록 변경한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,6 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
-    // REST Assured
-    testImplementation 'io.rest-assured:rest-assured'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
+++ b/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
@@ -2,10 +2,9 @@ package com.pancake.api.content;
 
 import com.pancake.api.content.application.dto.ContentRequest;
 import com.pancake.api.content.application.dto.ContentResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
@@ -20,14 +19,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 @SuppressWarnings("NonAsciiCharacters")
 class ContentAcceptanceTest {
 
+    @Autowired
     private WebTestClient client;
-
-    @BeforeEach
-    public void setUp(@LocalServerPort int port) {
-        client = WebTestClient.bindToServer()
-                .baseUrl("http://localhost:" + port)
-                .build();
-    }
 
     @Test
     void 컨텐츠를_등록할_수_있다() {

--- a/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
+++ b/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
@@ -20,7 +20,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 class ContentAcceptanceTest {
 
     @Autowired
-    private WebTestClient client;
+    WebTestClient client;
 
     @Test
     void 컨텐츠를_등록할_수_있다() {

--- a/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
+++ b/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
@@ -1,17 +1,16 @@
 package com.pancake.api.content.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pancake.api.content.application.ContentService;
 import com.pancake.api.content.application.dto.ContentRequest;
 import com.pancake.api.content.domain.Content;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient;
+import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
 
@@ -22,22 +21,25 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @WebMvcTest(ContentApiController.class)
 class ContentApiControllerTest {
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @Autowired
-    private MockMvc mockMvc;
-
     @MockBean
     private ContentService contentService;
 
+    private WebTestClient client;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context) {
+        client = MockMvcWebTestClient
+                .bindToApplicationContext(context)
+                .build();
+    }
+
     @Test
-    void postContentApi() throws Exception {
+    void postContentApi() {
         //given
         var request = new ContentRequest(TOTORO.URL, TOTORO.TITLE);
         var content = unwatchedContent(128, request.getUrl(), request.getTitle());
@@ -48,16 +50,16 @@ class ContentApiControllerTest {
         var result = post("/api/contents", request);
 
         //then
-        result.andExpectAll(
-                status().isCreated(),
-                jsonPath("$.id").value(equalTo(128)),
-                jsonPath("$.url").value(equalTo(TOTORO.URL)),
-                jsonPath("$.title").value(equalTo(TOTORO.TITLE))
-        );
+        result
+                .expectStatus().isCreated()
+                .expectBody()
+                .jsonPath("$.id").value(equalTo(128))
+                .jsonPath("$.url").value(equalTo(TOTORO.URL))
+                .jsonPath("$.title").value(equalTo(TOTORO.TITLE));
     }
 
     @Test
-    void getAllContentsApi() throws Exception {
+    void getAllContentsApi() {
         //given
         given(contentService.getAllContents()).willReturn(List.of(
                 unwatchedContent(1001, TOTORO.URL, TOTORO.TITLE),
@@ -68,16 +70,16 @@ class ContentApiControllerTest {
         var result = get("/api/contents");
 
         //then
-        result.andExpectAll(
-                status().isOk(),
-                jsonPath("$..id").value(contains(1001, 1002)),
-                jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL)),
-                jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE))
-        );
+        result
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$..id").value(contains(1001, 1002))
+                .jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL))
+                .jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE));
     }
 
     @Test
-    void getUnwatchedContentsApi() throws Exception {
+    void getUnwatchedContentsApi() {
         //given
         given(contentService.getUnwatchedContents()).willReturn(List.of(
                 unwatchedContent(1001, TOTORO.URL, TOTORO.TITLE),
@@ -88,16 +90,16 @@ class ContentApiControllerTest {
         var result = get("/api/contents/unwatched");
 
         //then
-        result.andExpectAll(
-                status().isOk(),
-                jsonPath("$..id").value(contains(1001, 1002)),
-                jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL)),
-                jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE))
-        );
+        result
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$..id").value(contains(1001, 1002))
+                .jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL))
+                .jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE));
     }
 
     @Test
-    void getWatchedContentsApi() throws Exception {
+    void getWatchedContentsApi() {
         //given
         given(contentService.getWatchedContents()).willReturn(List.of(
                 watchedContent(1001, TOTORO.URL, TOTORO.TITLE),
@@ -108,12 +110,12 @@ class ContentApiControllerTest {
         var result = get("/api/contents/watched");
 
         //then
-        result.andExpectAll(
-                status().isOk(),
-                jsonPath("$..id").value(contains(1001, 1002)),
-                jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL)),
-                jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE))
-        );
+        result
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$..id").value(contains(1001, 1002))
+                .jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL))
+                .jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE));
     }
 
     @Test
@@ -125,10 +127,10 @@ class ContentApiControllerTest {
         var result = patch("/api/contents/{id}/watch", 1234);
 
         //then
-        result.andExpectAll(
-                status().isOk(),
-                content().string(equalTo("true"))
-        );
+        result
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$").value(equalTo(true));
     }
 
     private Content unwatchedContent(long id, String url, String title) {
@@ -143,28 +145,18 @@ class ContentApiControllerTest {
         return new Content(id, url, title, watched);
     }
 
-    private ResultActions get(String path, Object... uriVariables) throws Exception {
-        return mockMvc.perform(
-                MockMvcRequestBuilders.get(path, uriVariables)
-        );
+    private ResponseSpec get(String path, Object... uriVariables) {
+        return client.get().uri(path, uriVariables).exchange();
     }
 
-    private ResultActions post(String path, Object body) throws Exception {
-        return mockMvc.perform(
-                MockMvcRequestBuilders.post(path)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(asJsonString(body))
-        );
+    private ResponseSpec post(String path, Object body) {
+        return client.post().uri(path)
+                .contentType(APPLICATION_JSON)
+                .bodyValue(body)
+                .exchange();
     }
 
-    private ResultActions patch(String urlTemplate, Object... uriVariables) throws Exception {
-        return mockMvc.perform(
-                MockMvcRequestBuilders.patch(urlTemplate, uriVariables)
-        );
+    private ResponseSpec patch(String path, Object... uriVariables) {
+        return client.patch().uri(path, uriVariables).exchange();
     }
-
-    private String asJsonString(Object object) throws Exception {
-        return objectMapper.writeValueAsString(object);
-    }
-
 }

--- a/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
+++ b/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
@@ -25,10 +25,10 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 class ContentApiControllerTest {
 
     @MockBean
-    private ContentService contentService;
+    ContentService contentService;
 
     @Autowired
-    private WebTestClient client;
+    WebTestClient client;
 
     @Test
     void postContentApi() {

--- a/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
+++ b/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
@@ -3,14 +3,12 @@ package com.pancake.api.content.api;
 import com.pancake.api.content.application.ContentService;
 import com.pancake.api.content.application.dto.ContentRequest;
 import com.pancake.api.content.domain.Content;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
-import org.springframework.test.web.servlet.client.MockMvcWebTestClient;
-import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
 
@@ -29,14 +27,8 @@ class ContentApiControllerTest {
     @MockBean
     private ContentService contentService;
 
+    @Autowired
     private WebTestClient client;
-
-    @BeforeEach
-    void setUp(WebApplicationContext context) {
-        client = MockMvcWebTestClient
-                .bindToApplicationContext(context)
-                .build();
-    }
 
     @Test
     void postContentApi() {


### PR DESCRIPTION
Resolve #5 

## 목표

- `WebTestClient`를 사용하여 인수테스트와 컨트롤러 레이어 테스트의 api를 동일하게 맞춘다


## 이 작업으로 변경된 것

- 의존성 `rest-assured` 제거 및 `webflux` 추가


## 변경 후 느낀 것

### 장점
- api가 동일하게 맞춰지니 개선 포인트들이 보여서 재밌을 것 같음
- `objectMapper`가 필요없어짐
- 이에 따라 `objectMapper` 사용으로 인한 `throws Exception` 코드도 없앨 수 있음
- controller test에서 변경이 클까봐 걱정했는데 기존 코드를 거의 그대로 쓸 수 있었음

### 단점
- 로그를 항상 찍는 기능이 찾기 힘들었고 이게 베스트 프랙티스인지 모르겠음ㅠ
  - [Spring WebTestClient 사용 시 항상 로그 찍기(like. alwaysDo)](https://velog.io/@viiviii/Spring-WebTestClient-사용-시-항상-로그-찍기-like-alwaysDo)


## 그 외 알게된 것

- [Spring은 어떻게 테스트 환경에 따라 WebTestClient를 자동 주입해주는걸까?](https://velog.io/@viiviii/Spring-WebTestClient는-어떻게-자동-주입되는걸까)
- [Spring은 어떻게 테스트에서 @Autowired 없이 WebApplicationContext를 가져올 수 있을까?](https://velog.io/@viiviii/Spring-테스트-시-WebApplicationContext는-Autowired-없이-가져올-수-있다)
- 공식 문서를 구경하다보니 꽤 pytest fixture처럼 메서드로 주입받아 쓰는 패턴을 보게돼서 긍정적으로 마음이 바뀜