### PR TITLE
✨ feat: 컨텐츠에 설명, 이미지URL 필드를 추가한다

### DIFF
--- a/src/main/java/com/pancake/api/content/api/ContentApiController.java
+++ b/src/main/java/com/pancake/api/content/api/ContentApiController.java
@@ -37,24 +37,6 @@ public class ContentApiController {
                 .toList());
     }
 
-    @GetMapping("/unwatched")
-    public ResponseEntity<List<ContentResponse>> getUnwatchedContents() {
-        final List<Content> contents = contentService.getUnwatchedContents();
-
-        return status(OK).body(contents.stream()
-                .map(ContentResponse::fromEntity)
-                .toList());
-    }
-
-    @GetMapping("/watched")
-    public ResponseEntity<List<ContentResponse>> getWatchedContents() {
-        final List<Content> contents = contentService.getWatchedContents();
-
-        return status(OK).body(contents.stream()
-                .map(ContentResponse::fromEntity)
-                .toList());
-    }
-
     @PatchMapping("{id}/watch")
     public ResponseEntity<Boolean> patchWatchContent(@PathVariable Long id) {
         final boolean watched = contentService.watch(id);

--- a/src/main/java/com/pancake/api/content/application/ContentService.java
+++ b/src/main/java/com/pancake/api/content/application/ContentService.java
@@ -23,14 +23,6 @@ public class ContentService {
         return contentRepository.findAll();
     }
 
-    public List<Content> getUnwatchedContents() {
-        return contentRepository.findByWatchedFalse();
-    }
-
-    public List<Content> getWatchedContents() {
-        return contentRepository.findByWatchedTrue();
-    }
-
     @Transactional
     public boolean watch(long id) {
         final var content = contentRepository.findById(id)

--- a/src/main/java/com/pancake/api/content/application/dto/ContentRequest.java
+++ b/src/main/java/com/pancake/api/content/application/dto/ContentRequest.java
@@ -12,8 +12,10 @@ public class ContentRequest {
 
     private String url;
     private String title;
+    private String description;
+    private String imageUrl;
 
     public Content toEntity() {
-        return new Content(url, title);
+        return new Content(url, title, description, imageUrl);
     }
 }

--- a/src/main/java/com/pancake/api/content/application/dto/ContentResponse.java
+++ b/src/main/java/com/pancake/api/content/application/dto/ContentResponse.java
@@ -11,11 +11,14 @@ import lombok.NoArgsConstructor;
 public class ContentResponse {
 
     private Long id;
-    private String title;
     private String url;
+    private String title;
+    private String description;
+    private String imageUrl;
     private boolean watched;
 
     public static ContentResponse fromEntity(Content content) {
-        return new ContentResponse(content.id(), content.title(), content.url(), content.isWatched());
+        return new ContentResponse(content.id(), content.url(), content.title(), content.description(),
+                content.imageUrl(), content.isWatched());
     }
 }

--- a/src/main/java/com/pancake/api/content/application/dto/ContentResponse.java
+++ b/src/main/java/com/pancake/api/content/application/dto/ContentResponse.java
@@ -13,8 +13,9 @@ public class ContentResponse {
     private Long id;
     private String title;
     private String url;
+    private boolean watched;
 
     public static ContentResponse fromEntity(Content content) {
-        return new ContentResponse(content.id(), content.title(), content.url());
+        return new ContentResponse(content.id(), content.title(), content.url(), content.isWatched());
     }
 }

--- a/src/main/java/com/pancake/api/content/domain/Content.java
+++ b/src/main/java/com/pancake/api/content/domain/Content.java
@@ -25,10 +25,14 @@ public class Content {
 
     private String title;
 
+    private String description;
+
+    private String imageUrl;
+
     private boolean watched;
 
-    public Content(String url, String title) {
-        this(null, url, title, false);
+    public Content(String url, String title, String description, String imageUrl) {
+        this(null, url, title, description, imageUrl, false);
     }
 
     public Long id() {
@@ -41,6 +45,14 @@ public class Content {
 
     public String title() {
         return this.title;
+    }
+
+    public String description() {
+        return this.description;
+    }
+
+    public String imageUrl() {
+        return this.imageUrl;
     }
 
     public boolean isWatched() {

--- a/src/main/java/com/pancake/api/content/infra/ContentRepository.java
+++ b/src/main/java/com/pancake/api/content/infra/ContentRepository.java
@@ -12,9 +12,5 @@ public interface ContentRepository extends Repository<Content, Long> {
 
     List<Content> findAll();
 
-    List<Content> findByWatchedFalse();
-
-    List<Content> findByWatchedTrue();
-
     Optional<Content> findById(long id);
 }

--- a/src/test/java/com/pancake/api/MemoryRepository.java
+++ b/src/test/java/com/pancake/api/MemoryRepository.java
@@ -3,7 +3,6 @@ package com.pancake.api;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.*;
-import java.util.function.Predicate;
 
 public class MemoryRepository<T> {
     private final Map<Long, T> data;
@@ -31,12 +30,6 @@ public class MemoryRepository<T> {
 
     public List<T> findAll() {
         return new ArrayList<>(data.values());
-    }
-
-    public List<T> findBy(Predicate<? super T> predicate) {
-        return new ArrayList<>(data.values()).stream()
-                .filter(predicate)
-                .toList();
     }
 
     public Optional<T> findById(long id) {

--- a/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
+++ b/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
@@ -27,10 +27,14 @@ class ContentAcceptanceTest {
     void 컨텐츠를_등록할_수_있다() {
         //given
         var 등록할_컨텐츠_주소 = "https://www.netflix.com/watch/60023642?trackId=14234261";
+        var 등록할_컨텐츠_이미지 = "https://occ-0-1360-2218.1.nflxso.net/dnm/api/v6/E8vDc";
         var 등록할_컨텐츠_제목 = "센과 치히로의 행방불명";
+        var 등록할_컨텐츠_설명 = "마녀가 지배하는 신비한 세계에 발을 들여놓은 치히로. 마녀에게 거역하는 자는 동물로 변하게 되는데...";
+
+        var 요청 = new ContentRequest(등록할_컨텐츠_주소, 등록할_컨텐츠_제목, 등록할_컨텐츠_이미지, 등록할_컨텐츠_설명);
 
         //when
-        var 등록된_컨텐츠 = 컨텐츠를_등록한다(등록할_컨텐츠_주소, 등록할_컨텐츠_제목);
+        var 등록된_컨텐츠 = 컨텐츠를_등록한다(요청);
 
         //then
         assertThat(컨텐츠를_모두_조회한다()).containsExactly(등록된_컨텐츠);
@@ -64,11 +68,11 @@ class ContentAcceptanceTest {
     }
 
     private ContentResponse 토토로_컨텐츠() {
-        return 컨텐츠를_등록한다(TOTORO.URL, TOTORO.TITLE);
+        return 컨텐츠를_등록한다(new ContentRequest(TOTORO.URL, TOTORO.TITLE, TOTORO.DESCRIPTION, TOTORO.IMAGE_URL));
     }
 
     private ContentResponse 포뇨_컨텐츠() {
-        return 컨텐츠를_등록한다(PONYO.URL, PONYO.TITLE);
+        return 컨텐츠를_등록한다(new ContentRequest(PONYO.URL, PONYO.TITLE, PONYO.DESCRIPTION, PONYO.IMAGE_URL));
     }
 
     private ContentResponse 시청한(ContentResponse content) {
@@ -77,8 +81,8 @@ class ContentAcceptanceTest {
         return content;
     }
 
-    private ContentResponse 컨텐츠를_등록한다(String url, String title) {
-        return post("/api/contents", new ContentRequest(url, title), ContentResponse.class);
+    private ContentResponse 컨텐츠를_등록한다(ContentRequest request) {
+        return post("/api/contents", request, ContentResponse.class);
     }
 
     private void 컨텐츠를_시청_처리_한다(long id) {

--- a/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
+++ b/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
@@ -50,32 +50,6 @@ class ContentAcceptanceTest {
     }
 
     @Test
-    void 시청할_수_있는_컨텐츠를_모두_조회할_수_있다() {
-        //given
-        var 토토로 = 토토로_컨텐츠();
-        시청한(포뇨_컨텐츠());
-
-        //when
-        var 시청할_컨텐츠_목록 = 시청할_컨텐츠를_모두_조회한다();
-
-        //then
-        assertThat(시청할_컨텐츠_목록).containsExactly(토토로);
-    }
-
-    @Test
-    void 이미_시청한_컨텐츠를_모두_조회할_수_있다() {
-        //given
-        토토로_컨텐츠();
-        var 포뇨 = 시청한(포뇨_컨텐츠());
-
-        //when
-        var 시청한_컨텐츠_목록 = 시청한_컨텐츠를_모두_조회한다();
-
-        //then
-        assertThat(시청한_컨텐츠_목록).containsExactly(포뇨);
-    }
-
-    @Test
     void 컨텐츠를_모두_조회할_수_있다() {
         //given
         var 시청하지_않은_토토로 = 토토로_컨텐츠();

--- a/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
+++ b/src/test/java/com/pancake/api/content/ContentAcceptanceTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import static com.pancake.api.content.NetflixConstant.PONYO;
 import static com.pancake.api.content.NetflixConstant.TOTORO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
@@ -44,7 +45,8 @@ class ContentAcceptanceTest {
         컨텐츠를_시청_처리_한다(포뇨.getId());
 
         //then
-        assertThat(시청한_컨텐츠를_모두_조회한다()).containsExactly(포뇨);
+        assertThat(컨텐츠를_모두_조회한다()).extracting("id", "watched")
+                .contains(tuple(포뇨.getId(), true)); // TODO
     }
 
     @Test
@@ -83,7 +85,8 @@ class ContentAcceptanceTest {
         var 모든_컨텐츠_목록 = 컨텐츠를_모두_조회한다();
 
         //then
-        assertThat(모든_컨텐츠_목록).containsExactly(시청하지_않은_토토로, 시청한_포뇨);
+        assertThat(모든_컨텐츠_목록).extracting("id")
+                .containsExactly(시청하지_않은_토토로.getId(), 시청한_포뇨.getId()); // TODO
     }
 
     private ContentResponse 토토로_컨텐츠() {
@@ -110,14 +113,6 @@ class ContentAcceptanceTest {
 
     private ContentResponse[] 컨텐츠를_모두_조회한다() {
         return get("/api/contents", ContentResponse[].class);
-    }
-
-    private ContentResponse[] 시청할_컨텐츠를_모두_조회한다() {
-        return get("/api/contents/unwatched", ContentResponse[].class);
-    }
-
-    private ContentResponse[] 시청한_컨텐츠를_모두_조회한다() {
-        return get("/api/contents/watched", ContentResponse[].class);
     }
 
     private <T> T get(String path, Class<T> expectBodyType) {

--- a/src/test/java/com/pancake/api/content/NetflixConstant.java
+++ b/src/test/java/com/pancake/api/content/NetflixConstant.java
@@ -2,14 +2,27 @@ package com.pancake.api.content;
 
 public enum NetflixConstant {
 
-    PONYO("https://www.netflix.com/watch/70106454?trackId=255824129", "벼랑 위의 포뇨"),
-    TOTORO("https://www.netflix.com/watch/60032294?trackId=254245392", "이웃집 토토로");
+    PONYO("https://www.netflix.com/watch/70106454?trackId=255824129", "벼랑 위의 포뇨",
+            """
+                    따분한 바다 생활이 싫어 가출한 물고기 공주 포뇨. 벼랑 위에 사는 인간 꼬마 소스케를 만나 친구가 된다.
+                    온 바다가 들썩들썩 포뇨를 찾아 나서지만, 이 고집불통 물고기의 소원은 오직 하나. 포뇨도 소스케처럼 인간이 될 거야!""",
+            "https://occ-0-1360-2218.1.nflxso.net/dnm/api/v6/E8vDc"),
+    TOTORO("https://www.netflix.com/watch/60032294?trackId=254245392",
+            "이웃집 토토로",
+            "엄마의 입원으로 두 어린 자매는 아빠와 함께 일본의 한 시골 마을에서 여름을 보내게 된다.",
+            "https://occ-0-1360-2218.1.nflxso.net/dnm/api/v6/E8vDc");
 
     public final String URL;
     public final String TITLE;
+    public final String DESCRIPTION;
 
-    NetflixConstant(String url, String title) {
+    public final String IMAGE_URL;
+
+
+    NetflixConstant(String url, String title, String description, String imageUrl) {
         this.URL = url;
         this.TITLE = title;
+        this.DESCRIPTION = description;
+        this.IMAGE_URL = imageUrl;
     }
 }

--- a/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
+++ b/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
@@ -33,8 +33,8 @@ class ContentApiControllerTest {
     @Test
     void postContentApi() {
         //given
-        var request = new ContentRequest(TOTORO.URL, TOTORO.TITLE);
-        var content = unwatchedContent(128, request.getUrl(), request.getTitle());
+        var request = new ContentRequest(TOTORO.URL, TOTORO.TITLE, TOTORO.DESCRIPTION, TOTORO.IMAGE_URL);
+        var content = content(128, TOTORO.URL, TOTORO.TITLE, TOTORO.DESCRIPTION, TOTORO.IMAGE_URL);
 
         given(contentService.save(any())).willReturn(content);
 
@@ -47,15 +47,17 @@ class ContentApiControllerTest {
                 .expectBody()
                 .jsonPath("$.id").value(equalTo(128))
                 .jsonPath("$.url").value(equalTo(TOTORO.URL))
-                .jsonPath("$.title").value(equalTo(TOTORO.TITLE));
+                .jsonPath("$.title").value(equalTo(TOTORO.TITLE))
+                .jsonPath("$.description").value(equalTo(TOTORO.DESCRIPTION))
+                .jsonPath("$.imageUrl").value(equalTo(TOTORO.IMAGE_URL));
     }
 
     @Test
     void getAllContentsApi() {
         //given
         given(contentService.getAllContents()).willReturn(List.of(
-                unwatchedContent(1001, TOTORO.URL, TOTORO.TITLE),
-                unwatchedContent(1002, PONYO.URL, PONYO.TITLE)
+                content(1001, TOTORO.URL, TOTORO.TITLE, TOTORO.DESCRIPTION, TOTORO.IMAGE_URL),
+                content(1002, PONYO.URL, PONYO.TITLE, PONYO.DESCRIPTION, PONYO.IMAGE_URL)
         ));
 
         //when
@@ -67,7 +69,9 @@ class ContentApiControllerTest {
                 .expectBody()
                 .jsonPath("$..id").value(contains(1001, 1002))
                 .jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL))
-                .jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE));
+                .jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE))
+                .jsonPath("$..description").value(contains(TOTORO.DESCRIPTION, PONYO.DESCRIPTION))
+                .jsonPath("$..imageUrl").value(contains(TOTORO.IMAGE_URL, PONYO.IMAGE_URL));
     }
 
     @Test
@@ -85,16 +89,8 @@ class ContentApiControllerTest {
                 .jsonPath("$").value(equalTo(true));
     }
 
-    private Content unwatchedContent(long id, String url, String title) {
-        return createContent(id, url, title, false);
-    }
-
-    private Content watchedContent(long id, String url, String title) {
-        return createContent(id, url, title, true);
-    }
-
-    private Content createContent(long id, String url, String title, boolean watched) {
-        return new Content(id, url, title, watched);
+    private Content content(long id, String url, String title, String description, String imageUrl) {
+        return new Content(id, url, title, description, imageUrl, false);
     }
 
     private ResponseSpec get(String path, Object... uriVariables) {

--- a/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
+++ b/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
@@ -71,46 +71,6 @@ class ContentApiControllerTest {
     }
 
     @Test
-    void getUnwatchedContentsApi() {
-        //given
-        given(contentService.getUnwatchedContents()).willReturn(List.of(
-                unwatchedContent(1001, TOTORO.URL, TOTORO.TITLE),
-                unwatchedContent(1002, PONYO.URL, PONYO.TITLE)
-        ));
-
-        //when
-        var result = get("/api/contents/unwatched");
-
-        //then
-        result
-                .expectStatus().isOk()
-                .expectBody()
-                .jsonPath("$..id").value(contains(1001, 1002))
-                .jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL))
-                .jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE));
-    }
-
-    @Test
-    void getWatchedContentsApi() {
-        //given
-        given(contentService.getWatchedContents()).willReturn(List.of(
-                watchedContent(1001, TOTORO.URL, TOTORO.TITLE),
-                watchedContent(1002, PONYO.URL, PONYO.TITLE)
-        ));
-
-        //when
-        var result = get("/api/contents/watched");
-
-        //then
-        result
-                .expectStatus().isOk()
-                .expectBody()
-                .jsonPath("$..id").value(contains(1001, 1002))
-                .jsonPath("$..url").value(contains(TOTORO.URL, PONYO.URL))
-                .jsonPath("$..title").value(contains(TOTORO.TITLE, PONYO.TITLE));
-    }
-
-    @Test
     void patchWatchContentApi() throws Exception {
         //given
         given(contentService.watch(anyLong())).willReturn(true);

--- a/src/test/java/com/pancake/api/content/application/ContentServiceTest.java
+++ b/src/test/java/com/pancake/api/content/application/ContentServiceTest.java
@@ -77,34 +77,6 @@ class ContentServiceTest {
                 .has(unwatchedContent, atIndex(1));
     }
 
-    @DisplayName("시청하지 않은 컨텐츠를 모두 조회한다")
-    @Test
-    void getUnwatchedContents() {
-        //given
-        existWatchedContent();
-        existUnwatchedContent();
-
-        //when
-        var actual = contentService.getUnwatchedContents();
-
-        //then
-        assertThat(actual).hasSize(1).are(unwatchedContent);
-    }
-
-    @DisplayName("시청한 컨텐츠를 모두 조회한다")
-    @Test
-    void getWatchedContents() {
-        //given
-        existWatchedContent();
-        existUnwatchedContent();
-
-        //when
-        var actual = contentService.getWatchedContents();
-
-        //then
-        assertThat(actual).hasSize(1).are(watchedContent);
-    }
-
     private void existWatchedContent() {
         saveContent(TOTORO).watch();
     }

--- a/src/test/java/com/pancake/api/content/application/ContentServiceTest.java
+++ b/src/test/java/com/pancake/api/content/application/ContentServiceTest.java
@@ -28,7 +28,7 @@ class ContentServiceTest {
     @Test
     void save() {
         //given
-        var request = new ContentRequest(TOTORO.URL, TOTORO.TITLE);
+        var request = new ContentRequest(TOTORO.URL, TOTORO.TITLE, TOTORO.DESCRIPTION, TOTORO.IMAGE_URL);
 
         //when
         var actual = contentService.save(request);
@@ -86,6 +86,6 @@ class ContentServiceTest {
     }
 
     private Content saveContent(NetflixConstant netflix) {
-        return contentService.save(new ContentRequest(netflix.URL, netflix.TITLE));
+        return contentService.save(new ContentRequest(netflix.URL, netflix.TITLE, netflix.DESCRIPTION, netflix.IMAGE_URL));
     }
 }

--- a/src/test/java/com/pancake/api/content/domain/ContentTest.java
+++ b/src/test/java/com/pancake/api/content/domain/ContentTest.java
@@ -12,7 +12,7 @@ class ContentTest {
     @Test
     void create() {
         //when
-        var content = new Content(TOTORO.URL, TOTORO.TITLE);
+        var content = new Content(TOTORO.URL, TOTORO.TITLE, TOTORO.DESCRIPTION, TOTORO.URL);
 
         //then
         assertThat(content.isWatched()).isFalse();
@@ -23,7 +23,7 @@ class ContentTest {
     @Test
     void watch() {
         //given
-        var content = new Content(TOTORO.URL, TOTORO.TITLE); // TODO
+        var content = new Content(TOTORO.URL, TOTORO.TITLE, TOTORO.DESCRIPTION, TOTORO.URL); // TODO
 
         //when
         boolean watched = content.watch();
@@ -36,7 +36,7 @@ class ContentTest {
     @Test
     void isWatched() {
         //given
-        var content = new Content(null, TOTORO.URL, TOTORO.TITLE, true); // TODO
+        var content = new Content(1L, TOTORO.URL, TOTORO.TITLE, TOTORO.DESCRIPTION, TOTORO.URL, true); // TODO
 
         //then
         assertThat(content.isWatched()).isTrue();

--- a/src/test/java/com/pancake/api/content/infra/MemoryContentRepository.java
+++ b/src/test/java/com/pancake/api/content/infra/MemoryContentRepository.java
@@ -3,19 +3,6 @@ package com.pancake.api.content.infra;
 import com.pancake.api.MemoryRepository;
 import com.pancake.api.content.domain.Content;
 
-import java.util.List;
-
-import static java.util.function.Predicate.not;
-
 public class MemoryContentRepository extends MemoryRepository<Content> implements ContentRepository {
 
-    @Override
-    public List<Content> findByWatchedFalse() {
-        return this.findBy(not(Content::isWatched));
-    }
-
-    @Override
-    public List<Content> findByWatchedTrue() {
-        return this.findBy(Content::isWatched);
-    }
 }


### PR DESCRIPTION
### 목표

- 이제 화면을 구현하기 위해 최소로 필요한 필드를 추가한다

### 이 작업으로 변경된 것

- content에 `description`, `imageUrl` 추가
- `시청할 컨텐츠 목록`, `시청한 컨텐츠 목록` API 제거

### 이유

아래의 내용들을 계속 고민 중인데 일단 가장 심플한 방법으로 해야 나중에 재밌다

- `썸네일 이미지`를 내 서버에 저장해야될 지 vs 제공된 URL 그대로 사용할지
- `시청한 컨텐츠`와 `시청할 컨텐츠`는 테이블이 1개일지 vs 나눠야할지

API 제거 이유는 필드 추가로 테스트를 수정하다보니 뭔가 잘못된게 아닐까 생각듦