### PR TITLE
:wrench: config: 데이터베이스 환경 별로 애플리케이션 프로필을 분리한다

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,23 +1,22 @@
 spring:
   datasource:
-    url: jdbc:h2:tcp://localhost/~/pancake
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: create # TODO: 운영에서는 validate 또는 none 사용해야 함
-    properties:
-      hibernate:
-        format_sql: true # SQL 줄바꿈 등 예쁘게 출력
-
-  lifecycle:
-    timeout-per-shutdown-phase: "30s"
-
-
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+  lifecycle.timeout-per-shutdown-phase: "30s"
 server:
-  shutdown: "graceful"
+  shutdown: graceful
 
+---
+
+spring:
+  config.activate.on-profile: local
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:h2:tcp://localhost/~/pancake}
+    username: ${SPRING_DATASOURCE_USERNAME:sa}
+    password: ${SPRING_DATASOURCE_PASSWORD:sa}
+  jpa:
+    hibernate.ddl-auto: create
+    properties.hibernate.format_sql: true
 logging.level:
   org.hibernate.SQL: debug # SQL logger 통해 출력

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:


### PR DESCRIPTION
## 로컬에서 사용 시 IDE 설정하기

![image](https://github.com/viiviii/friendly-pancake/assets/75404713/7fd2a93c-4f30-4f54-b4ec-b4ea623702bc)

argument로 프로필을 지정해서 사용

```
--spring.profiles.active=local
```