### PR TITLE
:wrench: config: 로컬 배포 시 k8s minikube를 사용한다

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 
-PORT="8080"
-IMAGE_NAME="api"
-NETWORK_NAME="api-net"
-NGINX_CONTAINER_NAME="nginx1"
-UPSTREAM_FILE="/etc/nginx/conf.d/docker-api.conf"
-CONTAINER_SHUTDOWN_TIMEOUT=30
-HEALTH_CHECK_MAX_RETRIES=5
-HEALTH_CHECK_RETRY_DELAY=5
+K8S_DEPLOYMENT_TEMPLATE="k8s/deployment.yaml.template"
+DOCKER_IMAGE_NAME="api"
 VERSION="$1"
 
 function check_input_version() {
@@ -17,64 +11,21 @@ function check_input_version() {
   fi
 }
 
-function is_blue_running() {
-  local container_names
-  container_names=$(docker network inspect $NETWORK_NAME --format '{{range .Containers}}{{.Name}} {{end}}')
-
-  [[ $container_names =~ "blue" ]]
-}
-
 function build_jar() {
   ./gradlew clean build
   check_success_or_exit $? "jar 빌드"
 }
 
-function build_docker_image() {
-  docker build --tag "$IMAGE_NAME:$VERSION" .
+function build_docker_image_in_local() {
+  eval "$(minikube docker-env)"
+  docker build --tag "$DOCKER_IMAGE_NAME:$VERSION" .
   check_success_or_exit $? "도커 이미지 빌드"
 }
 
-function remove_container() {
-  docker rm "$(docker ps -aq --filter status=exited --filter name="^/${1}$")"
-  check_success_or_exit $? "백업용으로 보관중이던 컨테이너 제거"
-}
-
-function run_container() {
-  docker run -d --name "$1" --network $NETWORK_NAME "$IMAGE_NAME:$VERSION"
-  check_success_or_exit $? "도커 컨테이너 생성 및 실행"
-}
-
-# TODO: 헬스체크
-function health_check() {
-  for retries in $(seq $HEALTH_CHECK_MAX_RETRIES); do
-    if docker exec $NGINX_CONTAINER_NAME curl -s "$1:$PORT/api/contents" >/dev/null; then
-      echo "✅ 새 버전 health check 성공"
-      return
-    fi
-
-    if [[ $retries -eq $HEALTH_CHECK_MAX_RETRIES ]]; then
-      echo "❌ 새 버전 health check 실패"
-      exit 1
-    fi
-
-    echo "...health check ${HEALTH_CHECK_RETRY_DELAY}초 후 재시도 ($retries)"
-    sleep $HEALTH_CHECK_RETRY_DELAY
-  done
-}
-
-function change_nginx_endpoint() {
-  docker exec $NGINX_CONTAINER_NAME sed -i "s/$1:$PORT/$2:$PORT/" $UPSTREAM_FILE
-  check_success_or_exit $? "Nginx 새 버전을 바라보도록 설정 변경"
-}
-
-function reload_nginx_config() {
-  docker exec $NGINX_CONTAINER_NAME nginx -s reload
-  check_success_or_exit $? "Nginx 설정 적용"
-}
-
-function stop_container() {
-  docker stop --time $CONTAINER_SHUTDOWN_TIMEOUT "$1" >/dev/null
-  check_success_or_exit $? "기존 버전 종료"
+function change_image_version() {
+  DOCKER_IMAGE=$DOCKER_IMAGE_NAME DOCKER_IMAGE_VERSION=$VERSION \
+  envsubst < "$K8S_DEPLOYMENT_TEMPLATE" | kubectl apply -f -
+  check_success_or_exit $? "Deployment image 새 버전으로 적용"
 }
 
 function check_success_or_exit() {
@@ -86,28 +37,16 @@ function check_success_or_exit() {
   fi
 }
 
+echo "🚀🚀🚀 시작 ver=$VERSION"
+
 # 배포 준비
 check_input_version
 
 build_jar
-build_docker_image
-
-if is_blue_running; then
-  current="blue"
-  target="green"
-else
-  current="green"
-  target="blue"
-fi
+build_docker_image_in_local
 
 # 배포 시작
-echo "🚀🚀🚀 시작, 기존 버전[$current] ➡️ 새 버전[$target]"
 
-remove_container $target
-run_container $target
-health_check $target
-change_nginx_endpoint $current $target
-reload_nginx_config
-stop_container $current
+change_image_version
 
 echo "🚀🚀🚀 완료"

--- a/k8s/deployment.yaml.template
+++ b/k8s/deployment.yaml.template
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  labels:
+    app: api
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+  selector:
+    app: api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-deployment
+  labels:
+    app: api
+spec:
+  selector:
+    matchLabels:
+      app: api
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: ${DOCKER_IMAGE}:${DOCKER_IMAGE_VERSION}
+          ports:
+            - name: api-port
+              containerPort: 8080
+          env:
+            - name: SPRING_DATASOURCE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: database-secret
+                  key: url
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: database-secret
+                  key: username
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database-secret
+                  key: password
+          startupProbe:
+            httpGet:
+              path: /api/contents # todo: 액추에이터로 변경하기
+              port: api-port
+            failureThreshold: 6
+            periodSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "/bin/sh", "-c", "sleep 5" ]

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pancake-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: api-service
+                port:
+                  number: 8080

--- a/k8s/secret-database.yaml.template
+++ b/k8s/secret-database.yaml.template
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: database-secret
+immutable: true
+stringData:
+  url: ${DATABASE_URL}
+  username: ${DATABASE_USERNAME}
+  password: "${DATABASE_PASSWORD}"


### PR DESCRIPTION
# minikube 설치

- 환경에 맞춰 [minikube 설치](https://minikube.sigs.k8s.io/docs/start/)


# 설정

- 현재 구성대로 로컬에서 사용하기 위함

## 필수
```bash
cd 프로젝트_루트

# minikube 시작
minikube start

# ingress 활성화, 이거 해야 nginx ingress class 다운받는 듯
minikube addons enable ingress

# 로컬에서 ingress 서비스 터널 시작
# 💡OS 비밀번호까지 쳐야하며 터미널 종료하면 안됨
minikube tunnel

# ingress 생성
kubectl apply -f k8s/ingress.yaml

# database secret 생성
DATABASE_URL= 데이터베이스_주소 DATABASE_USERNAME=사용자 DATABASE_PASSWORD=비밀번호 \
envsubst < k8s/secret-database.yaml.template | kubectl apply -f -
```

## 선택
```bash
# dashboard ui 사용
# 💡 이것도 사용하는 동안 터미널 끄면 안됨
minikube dashboard
```

# 사용
```
sh deploy.sh 0.0.1
```

<img width="856" alt="image" src="https://github.com/viiviii/friendly-pancake/assets/75404713/ece720b5-85af-459d-9e89-12f8f1fc6b9d">
