### PR TITLE
:zap: improve: 헬스 체크 시 actuator를 사용한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/k8s/deployment.yaml.template
+++ b/k8s/deployment.yaml.template
@@ -56,10 +56,16 @@ spec:
                   key: password
           startupProbe:
             httpGet:
-              path: /api/contents # todo: 액추에이터로 변경하기
+              path: /actuator/health/liveness
               port: api-port
             failureThreshold: 6
             periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: api-port
+            failureThreshold: 1
+            periodSeconds: 5
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
## actuator와 쿠버네티스

- 스프링부트에는 일반적으로 사용되는 `liveness` 및 `readiness` 가용성 상태에 대한 기본 지원이 포함되어 있음
- 쿠버네티스 환경에 배포된 경우 `actuator`는 `liveness`, `readiness`의 정보를 수집하고 health 엔드포인트에 노출함
  - 이러한 상태 그룹은 쿠버네티스 환경에서 실행되는 경우에만 자동으로 활성화 됨
  - 스프링부트가 환경 변수로 Kubernetes 배포 환경을 자동으로 감지해주기 때문


## sleep n초

그럼 스프링부트가 이렇게 관리해주니 기존 sleep n초를 걸어둔 것을 없앨 수 있을까?

<br>

스프링 블로그에서도 애플리케이션 상태는 스스로가 가장 잘 아니 이 값에 기여하는 것을 선택했다라고 소개되어있고,

> A polling-only model where you need to exercise checks to know the state of the application is incomplete. Only the application knows about its lifecycle (startup, shutdown) or can provide context about runtime errors (ending in a broken state while processing tasks). The Spring Boot application context is natively publishing those events during the lifecycle of the application; your application code should also be able to contribute to this.

<br>

`AvailabilityChangeEvent`의 리스너로 terminated 되기 전에 이벤트가 publish 되는 것을 보고 희망을 품었으나

<img width="997" alt="image" src="https://github.com/viiviii/friendly-pancake/assets/75404713/463ee6dc-7d09-43fe-9416-b7bd7f54bbd4">

<br>
<br>

변경하고 테스트 해보니 간헐적으로 실패하고 sleep을 걸어야지 안정적이길래 문서를 더 찾아봤음

<img width="986" alt="image" src="https://github.com/viiviii/friendly-pancake/assets/75404713/f0c25da2-d9c3-4a73-9bf2-98e7a0b41ddf">

<br>

이렇게 소개된 부분이 있길래 겸허히 받아들이기로 함

---

- https://spring.io/blog/2020/03/25/liveness-and-readiness-probes-with-spring-boot
- https://docs.spring.io/spring-boot/docs/3.0.5/reference/htmlsingle/#features.spring-application.application-availability
- https://docs.spring.io/spring-boot/docs/3.0.5/reference/htmlsingle/#actuator.endpoints.kubernetes-probes
- https://docs.spring.io/spring-boot/docs/3.0.5/reference/htmlsingle/#deployment.cloud.kubernetes