### PR TITLE
👷 cicd: api를 빌드하는 git workflow를 추가한다

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,23 @@
+## 🐳 Using build API Docker image
+
+```bash
+docker pull ghcr.io/viiviii/friendly-pancake-api:latest
+```
+
+### Example
+
+Runs as h2 in-memory DB:
+
+```bash
+docker run -d -p 8080:8080 ghcr.io/viiviii/friendly-pancake-api:latest
+```
+
+If want to set up:
+
+```bash
+docker run -d -p 8080:8080 \
+  -e SPRING_DATASOURCE_URL=jdbc:postgresql://192.168.10.192:8098/ \
+  -e SPRING_DATASOURCE_USERNAME=postgres \
+  -e SPRING_DATASOURCE_PASSWORD=1234 \
+  ghcr.io/viiviii/friendly-pancake-api:latest
+```

--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -1,0 +1,120 @@
+name: '📦 Build API'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - api/src/main/**
+
+env:
+  directory: api
+  java-version: 17
+  jar-file: api-0.0.1-SNAPSHOT.jar
+  jar-artifact-name: api-jar
+  image-registry: ghcr.io
+  image-registry-name: ghcr.io/${{ github.repository }}-api
+
+jobs:
+  jar:
+    name: '📦 JAR file'
+    runs-on: ubuntu-latest
+    steps:
+      - name: '⬇️ Checkout directory'
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: /${{ env.directory }}
+          sparse-checkout-cone-mode: false
+
+      - name: '🌱 Set up JDK'
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.java-version }}
+          distribution: temurin
+
+      - name: '🕵🏼 Validate Gradle wrapper'
+        uses: gradle/wrapper-validation-action@v1.1.0
+
+      - name: '📦 Build with Gradle'
+        uses: gradle/gradle-build-action@v2.7.0
+        with:
+          arguments: build
+          build-root-directory: ${{ env.directory }}
+
+      - name: '⬆️ Upload'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.jar-artifact-name }}
+          path: ${{ env.directory }}/build/libs/${{ env.jar-file }}
+          if-no-files-found: error
+          retention-days: 1
+
+  image:
+    name: '📦 Docker Image'
+    needs: jar
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: '⬇️ Checkout Dockerfile'
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: /${{ env.directory }}/Dockerfile
+          sparse-checkout-cone-mode: false
+
+      - name: '⬇️ Download JAR file'
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.jar-artifact-name }}
+          path: ${{ env.directory }}
+
+      - name: '💫 Generate Version'
+        id: version
+        uses: viiviii/headver-action@v1
+        with:
+          head: 0 # TODO
+          build: ${{ github.run_number }}
+
+      - name: '🔖 Generate metadata'
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.image-registry-name }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }},priority=902
+            type=semver,pattern=v{{major}},value=${{ steps.version.outputs.version }},priority=901
+            type=semver,pattern=b{{patch}},value=${{ steps.version.outputs.version }},priority=900
+            type=sha,prefix=,suffix=,priority=100
+
+      - name: '🌱 Set up QEMU'
+        uses: docker/setup-qemu-action@v2.2.0
+
+      - name: '🌱 Set up Docker Buildx'
+        uses: docker/setup-buildx-action@v2.9.1
+
+      - name: '🔑 Login to Registry'
+        uses: docker/login-action@v2.2.0
+        with:
+          registry: ${{ env.image-registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: '📦⬆️ Build and push'
+        uses: docker/build-push-action@v4.1.1
+        with:
+          context: ${{ env.directory }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            JAVA_VERSION=${{ env.java-version }}
+            JAR_FILE=${{ env.jar-file }}
+
+      - name: '🖨️ Output Summary'
+        run: |
+          echo "### Install from the command line" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.image-registry-name }}:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM eclipse-temurin:17
-ARG JAR_FILE=./build/libs/api-0.0.1-SNAPSHOT.jar
-COPY ${JAR_FILE} ./app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,8 @@
+ARG JAVA_VERSION
+FROM eclipse-temurin:${JAVA_VERSION}
+
+ARG JAR_FILE
+COPY ${JAR_FILE} app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,8 +1,4 @@
 spring:
-  datasource:
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
   lifecycle.timeout-per-shutdown-phase: "30s"
 server:
   shutdown: graceful
@@ -11,10 +7,6 @@ server:
 
 spring:
   config.activate.on-profile: local
-  datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:h2:tcp://localhost/~/pancake}
-    username: ${SPRING_DATASOURCE_USERNAME:sa}
-    password: ${SPRING_DATASOURCE_PASSWORD:sa}
   jpa:
     hibernate.ddl-auto: create
     properties.hibernate.format_sql: true

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -1,5 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:h2:mem:test
-    username: sa
-    password:


### PR DESCRIPTION
## 작업

- 공식 문서에 다 구현돼어 있어 거의 복붙함


> 🔗 Build JAR file
> https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle


> 🔗 Build Docker image
> https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages

> 🔗 Build Docker image(Multi-platform image)
> https://docs.docker.com/build/ci/github-actions/multi-platform/

<br>

## 메모

- git checkout action 사용 시 원하는 파일, 디렉토리만 가져올 수 있는데 "/"를 붙이지 않으면 매칭되는 패턴으로 전부 가져옴
- Docker image 사용 시 EC2는 amd고 내 맥북은 arm이라 테스트가 불편하길래 멀티 플랫폼으로 빌드함
- datasource 환경 변수는 어차피 프로덕션에선 주입해서 쓸거라 굳이 왜 있어야하지?싶어서 제거함
  - 기본적으로 인메모리로 동작하면 더 편하지 않을까? 기존엔 설정을 안하면 실행 자체가 안됐으니까
 
## 궁금

- 자바 버전은 보통 어디서 관리하는지?
- MAJOR 버전은 수동으로 판단해서 올리는건가? 뭔가 통합 테스트가 이전 버전과 호환 안되면 자동으로 올라갔으면 좋겠음
- 문서 용도로 Dockerfile에 포트를 명시했는데 다른 이미지(nginx, postgres)는 레이어에서 잘 나오는데 난 map으로 보여지는 이유