### PR TITLE
👷 cicd: api 빌드 후 배포를 시작하는 트리거를 추가한다

### DIFF
--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -54,7 +54,7 @@ jobs:
     needs: jar
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: '⬇️ Checkout Dockerfile'
@@ -118,3 +118,11 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.image-registry-name }}:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: '🗒️ Note image name to commit'
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git fetch origin refs/notes/commits:refs/notes/commits
+          git notes add -m "${{ env.image-registry-name }}:${{ steps.version.outputs.version }}" ${{ github.sha }}
+          git push origin refs/notes/commits

--- a/.github/workflows/update-api-image-on-infra.yml
+++ b/.github/workflows/update-api-image-on-infra.yml
@@ -1,0 +1,43 @@
+name: '🔫 trigger-api-deployment'
+
+on:
+  workflow_run:
+    workflows: [ '📦 Build API' ]
+    types: [ completed ]
+    branches: [ main ]
+
+jobs:
+  update-and-push:
+    name: '⬆️ Pushing API image change'
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
+    env:
+      file: compose-service-api.yml
+    steps:
+      - name: '⬇️ Checkout'
+        uses: actions/checkout@v3
+        with:
+          ref: infra
+          sparse-checkout: /${{ env.file }}
+          sparse-checkout-cone-mode: false
+          token: ${{ secrets.PAT_FOR_TRIGGER_WORKFLOW }}
+
+      - name: '⬇️ Get image name from commit note'
+        id: image
+        run: |
+          git fetch origin refs/notes/commits:refs/notes/commits
+          note="$(git notes show ${{ github.event.workflow_run.head_sha }})"
+          echo "name=$note" >> $GITHUB_OUTPUT
+
+      - name: '🆙 Update api image'
+        run: |
+          sed -i "s|image: .*|image: ${{ steps.image.outputs.name }}|g" $file
+
+      - name: '⬆️ Push commit'
+        run: |
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git commit -am "🐳 Update image to ${{ steps.image.outputs.name }}"
+          git push origin HEAD


### PR DESCRIPTION
## 목표

- api build가 완료되면 해당 빌드 버전으로 배포하는 트리거를 작성한다


## 작업

- 필요 작업 권한이 있는 PAT 추가
- git note를 사용하여 commit에 빌드 버전 추가
- build workflow가 pass하면 시작되는 workflow 추가


## 메모

### PAT 사용 이유

- [git workflow에서 다른 workflow를 트리거하기 위해](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

### note 사용 이유

- 다른 workflofw에서 빌드가 발생한 SHA 커밋의 완료된 빌드 이미지를 알기 위해서
- 원래는 artifact를 사용하는 것 같으나 그저 텍스트인데 저렇게 쓰는게 좀 싫어서 메타 데이터로 검색했다가 10년 전쯤 사망한 듯한 git notes로 선택함

> https://git-scm.com/docs/git-notes
> https://gist.github.com/topheman/ec8cde7c54e24a785e52