### PR TITLE
🔧 config: flyway로 db 스키마를 관리한다

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'org.flywaydb:flyway-core'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,5 +1,10 @@
 spring:
-  lifecycle.timeout-per-shutdown-phase: "30s"
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
 server:
   shutdown: graceful
 
@@ -8,7 +13,8 @@ server:
 spring:
   config.activate.on-profile: local
   jpa:
-    hibernate.ddl-auto: create
-    properties.hibernate.format_sql: true
-logging.level:
-  org.hibernate.SQL: debug # SQL logger 통해 출력
+    properties:
+      hibernate.format_sql: true
+logging:
+  level:
+    org.hibernate.SQL: debug # SQL logger 통해 출력

--- a/api/src/main/resources/db/migration/V20230822_1__Create_table_contents.sql
+++ b/api/src/main/resources/db/migration/V20230822_1__Create_table_contents.sql
@@ -1,0 +1,8 @@
+create table contents (
+    id          bigserial       primary key,
+    description varchar(255)    not null,
+    image_url   varchar(255)    not null,
+    title       varchar(255)    not null,
+    url         varchar(255)    not null,
+    watched     boolean         not null default false
+);


### PR DESCRIPTION
## 목표

- flyway로 DB 스키마를 관리한다


## 작업

- [flyway dependency 추가](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.data-initialization.migration-tool.flyway)
- 테이블 생성 sql 스크립트 작성
- ddl-auto validate로 변경

## 메모

### 운영에서 ddl-auto validate로 변경한 이유

원래는 기본 값인 `none`을 사용했는데 이제 스키마를 flyway가 담당하므로 hibernate 엔티티와 같은지 확인하면 좋을 것 같아서 변경함


### 테스트 구성이 고민됨

- A안: 테스트에서도 flyway + validate 사용
- B안: 테스트에서는 flyway enabled false로 하고 hibernate 생성 기능을 사용

테스트에서도 동일하게 구성할 경우 테스트 신뢰도가 좋아진다 생각함

하지만 고민 포인트는 현재 sql 스크립트를 운영 db인 postgres 기준으로 작성하고 있는데
테스트 db는 h2이기 때문에 추후 문법 등이 유효하지 않을 가능성이 있음 → h2 스크립트 필요해짐 → 관리 포인트 증가

결론은 아직까진 에러가 안나고 있으니 문제 생기면 고민해보자

++
- TestContainers 사용으로 실제 postgres db로 테스트 하는 것도 좋아보임
- flyway-test-extension이었나가 있는데 cleanup이 지원됨
  - 다만 잠깐 테스트해보니 테이블을 drop하는 방식이라 개별 테스트 실행마다 쓰기엔 살짝 느릴 수도 있음



