### PR TITLE
:sparkles: feat: api url로 https 프로토콜을 받을 수 있게 변경한다

### DIFF
--- a/app/lib/api/url.dart
+++ b/app/lib/api/url.dart
@@ -1,9 +1,8 @@
 part of 'api.dart';
 
-final _domain = Domain();
+final _url = Url(Domain());
 
-Uri url(String path) =>
-    Uri.parse(_domain.fromEnvironment()).resolve('api/$path');
+Uri url(String path) => _url.path(path);
 
 class Domain {
   static const _dartDefineKey = 'API_HOST'; // --dart-define=<foo=bar>
@@ -13,4 +12,15 @@ class Domain {
   String fromEnvironment() {
     return String.fromEnvironment(_dartDefineKey, defaultValue: _defaultValue);
   }
+}
+
+class Url {
+  final Uri _url;
+
+  Url(Domain domain)
+      : _url = Uri.parse(domain.fromEnvironment()).resolve('api/');
+
+  Uri call() => _url;
+
+  Uri path(String path) => _url.resolve(path);
 }

--- a/app/lib/api/url.dart
+++ b/app/lib/api/url.dart
@@ -5,7 +5,7 @@ final _url = Url(Domain());
 Uri url(String path) => _url.path(path);
 
 class Domain {
-  static const dartDefineKey = 'API_HOST'; // --dart-define=<foo=bar>
+  static const dartDefineKey = 'API_URL'; // --dart-define=<foo=bar>
 
   final String _defaultValue = 'http://localhost:8080';
 

--- a/app/lib/api/url.dart
+++ b/app/lib/api/url.dart
@@ -5,12 +5,12 @@ final _url = Url(Domain());
 Uri url(String path) => _url.path(path);
 
 class Domain {
-  static const _dartDefineKey = 'API_HOST'; // --dart-define=<foo=bar>
+  static const dartDefineKey = 'API_HOST'; // --dart-define=<foo=bar>
 
   final String _defaultValue = 'http://localhost:8080';
 
   String fromEnvironment() {
-    return String.fromEnvironment(_dartDefineKey, defaultValue: _defaultValue);
+    return String.fromEnvironment(dartDefineKey, defaultValue: _defaultValue);
   }
 }
 

--- a/app/lib/api/url.dart
+++ b/app/lib/api/url.dart
@@ -2,7 +2,8 @@ part of 'api.dart';
 
 final _domain = Domain();
 
-Uri url(String path) => Uri.http(_domain.fromEnvironment(), 'api/$path');
+Uri url(String path) =>
+    Uri.parse(_domain.fromEnvironment()).resolve('api/$path');
 
 class Domain {
   static const _dartDefineKey = 'API_HOST'; // --dart-define=<foo=bar>

--- a/app/lib/api/url.dart
+++ b/app/lib/api/url.dart
@@ -1,7 +1,15 @@
 part of 'api.dart';
 
-const _dartDefineKey = 'API_HOST'; // --dart-define=<foo=bar>
-const _local = 'localhost:8080';
-const _host = String.fromEnvironment(_dartDefineKey, defaultValue: _local);
+final _domain = Domain();
 
-Uri url(String path) => Uri.http(_host, 'api/$path');
+Uri url(String path) => Uri.http(_domain.fromEnvironment(), 'api/$path');
+
+class Domain {
+  static const _dartDefineKey = 'API_HOST'; // --dart-define=<foo=bar>
+
+  final String _defaultValue = 'http://localhost:8080';
+
+  String fromEnvironment() {
+    return String.fromEnvironment(_dartDefineKey, defaultValue: _defaultValue);
+  }
+}

--- a/app/test/api/url_test.dart
+++ b/app/test/api/url_test.dart
@@ -1,72 +1,78 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pancake_app/api/api.dart';
 
-class StubDomain implements Domain {
-  final String _domain;
-
-  StubDomain(this._domain);
-
-  @override
-  String fromEnvironment() => _domain;
-}
-
 void main() {
-  test('Domain defaultValue', () {
-    final domain = Domain();
-    expect(domain.fromEnvironment(), 'http://localhost:8080');
+  test('url()', () {
+    expect(url('posts').path, '/api/posts');
   });
 
-  test('url path http', () {
-    //given
-    final url = Url(StubDomain('http://localhost:8080'));
+  group('Domain', () {
+    test('dartDefineKey', () {
+      expect(Domain.dartDefineKey, 'API_HOST');
+    });
 
-    //when
-    final actual = url.path('posts');
-
-    //then
-    expect(actual, Uri.http('localhost:8080', 'api/posts'));
+    test('defaultValue', () {
+      expect(Domain().fromEnvironment(), 'http://localhost:8080');
+    });
   });
 
-  test('url path https', () {
-    //given
-    final url = Url(StubDomain('https://my.example.site:443'));
+  group('Url', () {
+    group('url()', () {
+      test('when domain is http', () {
+        //given
+        final url = Url(StubDomain('http://localhost:80'));
 
-    //when
-    final actual = url.path('posts');
+        //when
+        final actual = url();
 
-    //then
-    expect(actual, Uri.https('my.example.site:443', 'api/posts'));
-  });
+        //then
+        expect(actual, Uri.http('localhost:80', 'api/'));
+      });
 
-  test('path()를 여러 번 호출해도 /api/ 뒤의 마지막 {path}만 변경 된다', () {
-    //given
-    final url = Url(StubDomain('http://localhost:8080'));
+      test('when domain is https', () {
+        //given
+        final url = Url(StubDomain('https://my.example.site:443'));
 
-    //then
-    expect('${url.path('posts')}', 'http://localhost:8080/api/posts');
-    expect('${url.path('users')}', 'http://localhost:8080/api/users');
-  });
+        //when
+        final actual = url();
 
-  test('url() with http', () {
-    //given
-    final url = Url(StubDomain('http://www.localhost:81'));
+        //then
+        expect(actual, Uri.https('my.example.site:443', 'api/'));
+      });
+    });
 
-    //when
-    final actual = url();
+    group('path()', () {
+      test('when domain is http', () {
+        //given
+        final url = Url(StubDomain('http://localhost:80'));
 
-    //then
-    expect(actual, Uri.http('www.localhost:81', 'api/'));
-  });
+        //when
+        final actual = url.path('posts');
 
-  test('url() with https', () {
-    //given
-    final url = Url(StubDomain('https://my.example.site:8443'));
+        //then
+        expect(actual, Uri.http('localhost:80', 'api/posts'));
+      });
 
-    //when
-    final actual = url();
+      test('when domain is https', () {
+        //given
+        final url = Url(StubDomain('https://my.example.site:443'));
 
-    //then
-    expect(actual, Uri.https('my.example.site:8443', 'api/'));
+        //when
+        final actual = url.path('posts');
+
+        //then
+        expect(actual, Uri.https('my.example.site:443', 'api/posts'));
+      });
+
+      test('여러 번 호출해도 /api/를 제외한 {path}만 변경 된다', () {
+        //given
+        final url = Url(StubDomain('http://localhost:8080'));
+
+        //then
+        expect(url.path('posts').path, '/api/posts');
+        expect(url.path('users').path, '/api/users');
+      });
+    });
   });
 
   group('Uri 학습 테스트', () {
@@ -112,4 +118,13 @@ void main() {
       expect('$actual', 'http://localhost:8080/api/contents');
     });
   });
+}
+
+class StubDomain implements Domain {
+  final String _domain;
+
+  StubDomain(this._domain);
+
+  @override
+  String fromEnvironment() => _domain;
 }

--- a/app/test/api/url_test.dart
+++ b/app/test/api/url_test.dart
@@ -9,6 +9,8 @@ class Url {
       : _url = Uri.parse(domain.fromEnvironment()).resolve('api/');
 
   Uri call() => _url;
+
+  Uri path(String path) => _url.resolve(path);
 }
 
 class StubDomain implements Domain {
@@ -24,6 +26,37 @@ void main() {
   test('Domain defaultValue', () {
     final domain = Domain();
     expect(domain.fromEnvironment(), 'http://localhost:8080');
+  });
+
+  test('url path http', () {
+    //given
+    final url = Url(StubDomain('http://localhost:8080'));
+
+    //when
+    final actual = url.path('posts');
+
+    //then
+    expect(actual, Uri.http('localhost:8080', 'api/posts'));
+  });
+
+  test('url path https', () {
+    //given
+    final url = Url(StubDomain('https://my.example.site:443'));
+
+    //when
+    final actual = url.path('posts');
+
+    //then
+    expect(actual, Uri.https('my.example.site:443', 'api/posts'));
+  });
+
+  test('path()를 여러 번 호출해도 /api/ 뒤의 마지막 {path}만 변경 된다', () {
+    //given
+    final url = Url(StubDomain('http://localhost:8080'));
+
+    //then
+    expect('${url.path('posts')}', 'http://localhost:8080/api/posts');
+    expect('${url.path('users')}', 'http://localhost:8080/api/users');
   });
 
   test('url(String path) ', () {

--- a/app/test/api/url_test.dart
+++ b/app/test/api/url_test.dart
@@ -2,15 +2,55 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pancake_app/api/api.dart' as api;
 import 'package:pancake_app/api/api.dart';
 
+class Url {
+  final Uri _url;
+
+  Url(Domain domain)
+      : _url = Uri.parse(domain.fromEnvironment()).resolve('api/');
+
+  Uri call() => _url;
+}
+
+class StubDomain implements Domain {
+  final String _domain;
+
+  StubDomain(this._domain);
+
+  @override
+  String fromEnvironment() => _domain;
+}
+
 void main() {
   test('Domain defaultValue', () {
     final domain = Domain();
     expect(domain.fromEnvironment(), 'http://localhost:8080');
   });
 
-  test('url()', () {
+  test('url(String path) ', () {
     expect('${api.url('contents')}', 'http://localhost:8080/api/contents');
     expect('${api.url('users')}', 'http://localhost:8080/api/users');
+  });
+
+  test('url() with http', () {
+    //given
+    final url = Url(StubDomain('http://www.localhost:81'));
+
+    //when
+    final actual = url();
+
+    //then
+    expect(actual, Uri.http('www.localhost:81', 'api/'));
+  });
+
+  test('url() with https', () {
+    //given
+    final url = Url(StubDomain('https://my.example.site:8443'));
+
+    //when
+    final actual = url();
+
+    //then
+    expect(actual, Uri.https('my.example.site:8443', 'api/'));
   });
 
   group('Uri 학습 테스트', () {

--- a/app/test/api/url_test.dart
+++ b/app/test/api/url_test.dart
@@ -1,17 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pancake_app/api/api.dart' as api;
 import 'package:pancake_app/api/api.dart';
-
-class Url {
-  final Uri _url;
-
-  Url(Domain domain)
-      : _url = Uri.parse(domain.fromEnvironment()).resolve('api/');
-
-  Uri call() => _url;
-
-  Uri path(String path) => _url.resolve(path);
-}
 
 class StubDomain implements Domain {
   final String _domain;
@@ -57,11 +45,6 @@ void main() {
     //then
     expect('${url.path('posts')}', 'http://localhost:8080/api/posts');
     expect('${url.path('users')}', 'http://localhost:8080/api/users');
-  });
-
-  test('url(String path) ', () {
-    expect('${api.url('contents')}', 'http://localhost:8080/api/contents');
-    expect('${api.url('users')}', 'http://localhost:8080/api/users');
   });
 
   test('url() with http', () {

--- a/app/test/api/url_test.dart
+++ b/app/test/api/url_test.dart
@@ -8,7 +8,7 @@ void main() {
 
   group('Domain', () {
     test('dartDefineKey', () {
-      expect(Domain.dartDefineKey, 'API_HOST');
+      expect(Domain.dartDefineKey, 'API_URL');
     });
 
     test('defaultValue', () {

--- a/app/test/api/url_test.dart
+++ b/app/test/api/url_test.dart
@@ -1,7 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pancake_app/api/api.dart' as api;
+import 'package:pancake_app/api/api.dart';
 
 void main() {
+  test('Domain defaultValue', () {
+    final domain = Domain();
+    expect(domain.fromEnvironment(), 'http://localhost:8080');
+  });
+
   test('url()', () {
     expect('${api.url('contents')}', 'http://localhost:8080/api/contents');
     expect('${api.url('users')}', 'http://localhost:8080/api/users');


### PR DESCRIPTION
Resolved: #53 

# 목표

- 기존에 http로 고정되어 있던 프로토콜을 https도 가능하게 변경한다

# 작업

- 코드 변경
- git actions API_HOST의 IP 주소를 API_URL url로 변경
