### PR TITLE
🔧 config: CORS PATCH 메서드를 허용한다

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,10 +11,7 @@ server {
                add_header 'Access-Control-Allow-Origin' 'https://viiviii.github.io';
                add_header 'Access-Control-Allow-Methods' 'GET, HEAD, POST, PATCH';
                add_header 'Access-Control-Allow-Headers' 'Content-Type';
-               #
-               # Tell client that this pre-flight info is valid for 20 days
-               #
-               add_header 'Access-Control-Max-Age' 1728000;
+               add_header 'Access-Control-Max-Age' 3600;
                add_header 'Content-Length' 0;
                return 204;
             }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -8,15 +8,16 @@ server {
 
     location /api {
         if ($request_method = 'OPTIONS') {
-               add_header 'Access-Control-Allow-Origin' 'https://viiviii.github.io';
-               add_header 'Access-Control-Allow-Methods' 'GET, HEAD, POST, PATCH';
-               add_header 'Access-Control-Allow-Headers' 'Content-Type';
-               add_header 'Access-Control-Max-Age' 3600;
-               add_header 'Content-Length' 0;
-               return 204;
-            }
+            add_header Access-Control-Allow-Origin  'https://viiviii.github.io';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, POST, PATCH';
+            add_header Access-Control-Allow-Headers 'Content-Type';
+            add_header Access-Control-Max-Age       '3600';
+            add_header Content-Length               '0';
 
-        add_header 'Access-Control-Allow-Origin' 'https://viiviii.github.io';
+            return 204;
+        }
+
+        add_header Access-Control-Allow-Origin      'https://viiviii.github.io';
         proxy_pass http://backend;
     }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -9,6 +9,7 @@ server {
     location /api {
         if ($request_method = 'OPTIONS') {
                add_header 'Access-Control-Allow-Origin' 'https://viiviii.github.io';
+               add_header 'Access-Control-Allow-Methods' 'GET, HEAD, POST, PATCH';
                add_header 'Access-Control-Allow-Headers' 'Content-Type';
                #
                # Tell client that this pre-flight info is valid for 20 days


### PR DESCRIPTION
Resolved: #54 

## CORS Max Age 1시간으로 변경 이유

- 기존에는 참고한 사이트가 20일로 되어있길래 따라했는데 이번에 문서를 보다보니 [Max Age는 브라우저마다 최대 값이 달랐다](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age)
- 그래서 1시간으로 바꿨음

 
