### PR TITLE
✨ feat: 컨텐츠 목록 조회 시 시청 주소가 있는 컨텐츠만 반환한다

### DIFF
--- a/api/src/main/java/com/pancake/api/content/application/ContentService.java
+++ b/api/src/main/java/com/pancake/api/content/application/ContentService.java
@@ -19,7 +19,9 @@ public class ContentService {
     }
 
     public List<Content> getAllContents() {
-        return contentRepository.findAll();
+        return contentRepository.findAll().stream()
+                .filter(Content::canWatch)
+                .toList();
     }
 
     public Content getContent(long id) {

--- a/api/src/main/java/com/pancake/api/content/domain/Content.java
+++ b/api/src/main/java/com/pancake/api/content/domain/Content.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
+import static org.springframework.util.StringUtils.hasText;
 
 
 @Entity
@@ -65,5 +66,9 @@ public class Content {
 
     public void addUrl(String url) {
         this.url = url;
+    }
+
+    public boolean canWatch() {
+        return hasText(getUrl());
     }
 }

--- a/api/src/test/java/com/pancake/api/content/application/ContentServiceTest.java
+++ b/api/src/test/java/com/pancake/api/content/application/ContentServiceTest.java
@@ -1,12 +1,15 @@
 package com.pancake.api.content.application;
 
+import com.pancake.api.content.domain.Content;
 import com.pancake.api.content.domain.ContentRepository;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -16,6 +19,21 @@ class ContentServiceTest {
 
     private final ContentRepository contentRepository = mock(ContentRepository.class);
     private final ContentService contentService = new ContentService(contentRepository);
+
+    @DisplayName("컨텐츠 목록 조회 시 시청할 수 없는 컨텐츠는 제외된다")
+    @Test
+    void getAllContentsExcludesUnwatchableContent() {
+        //given
+        var content = mock(Content.class);
+        given(content.canWatch()).willReturn(false, true, true);
+        given(contentRepository.findAll()).willReturn(List.of(content, content, content));
+
+        //when
+        var actual = contentService.getAllContents();
+
+        //then
+        assertThat(actual).hasSize(2);
+    }
 
     @DisplayName("존재하지 않는 컨텐츠 조회 시 예외가 발생한다")
     @Test

--- a/api/src/test/java/com/pancake/api/content/domain/ContentTest.java
+++ b/api/src/test/java/com/pancake/api/content/domain/ContentTest.java
@@ -2,6 +2,9 @@ package com.pancake.api.content.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,6 +44,34 @@ class ContentTest {
 
         //then
         assertThat(content.getUrl()).isEqualTo("https://www.netflix.com/watch/999");
+    }
+
+    @DisplayName("시청 주소가 있는 컨텐츠는 시청 가능하다")
+    @Test
+    void canWatchIsTrue() {
+        //given
+        var content = createContent();
+        content.addUrl("https://www.netflix.com/watch/999");
+
+        //when
+        var actual = content.canWatch();
+        //then
+        assertThat(actual).isTrue();
+    }
+
+    @DisplayName("시청 주소가 없는 컨텐츠는 시청 불가하다")
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = " ")
+    void canWatchIsFalse(String url) {
+        //given
+        var content = createContent();
+        content.addUrl(url);
+
+        //when
+        var actual = content.canWatch();
+        //then
+        assertThat(actual).isFalse();
     }
 
     private Content createContent() {


### PR DESCRIPTION
컨텐츠 생성과 시청 주소 추가를 분리했기 때문에
실제로 사용자에게 보여질 때는 시청 주소가 있는 컨텐츠만 반환해야 한다