### PR TITLE
🐛 fix: 가짜로 성공시킨 기능을 실제로 동작하게 수정한다

### DIFF
--- a/api/src/main/java/com/pancake/api/content/api/ContentApiController.java
+++ b/api/src/main/java/com/pancake/api/content/api/ContentApiController.java
@@ -25,7 +25,7 @@ public class ContentApiController {
     @PostMapping
     public ResponseEntity<ContentResponse> save(@RequestBody SaveContentCommand command) {
         final var content = contentService.save(command);
-        final var response = ContentResponse.fromEntity(content);
+        final var response = new ContentResponse(content);
 
         return status(CREATED).body(response);
     }
@@ -33,7 +33,7 @@ public class ContentApiController {
     @GetMapping
     public ResponseEntity<List<WatchableContentResponse>> getAll() {
         final var contents = contentService.getAllContents();
-        final var response = contents.stream().map(WatchableContentResponse::fromEntity).toList();
+        final var response = contents.stream().map(WatchableContentResponse::new).toList();
 
         return status(OK).body(response);
     }

--- a/api/src/main/java/com/pancake/api/content/api/ContentApiController.java
+++ b/api/src/main/java/com/pancake/api/content/api/ContentApiController.java
@@ -1,5 +1,6 @@
 package com.pancake.api.content.api;
 
+import com.pancake.api.content.application.AddPlayback;
 import com.pancake.api.content.application.AddPlaybackCommand;
 import com.pancake.api.content.application.ContentService;
 import com.pancake.api.content.application.SaveContentCommand;
@@ -19,6 +20,8 @@ public class ContentApiController {
 
     private final ContentService contentService;
 
+    private final AddPlayback addPlayback;
+
     @PostMapping
     public ResponseEntity<ContentResponse> save(@RequestBody SaveContentCommand command) {
         final var content = contentService.save(command);
@@ -37,7 +40,7 @@ public class ContentApiController {
 
     @PostMapping("{id}/playbacks")
     public ResponseEntity<Void> addPlayback(@PathVariable Long id, @RequestBody AddPlaybackCommand command) {
-        contentService.addPlayback(id, command);
+        addPlayback.with(id, command);
 
         return status(NO_CONTENT).build();
     }

--- a/api/src/main/java/com/pancake/api/content/api/ContentResponse.java
+++ b/api/src/main/java/com/pancake/api/content/api/ContentResponse.java
@@ -1,12 +1,10 @@
 package com.pancake.api.content.api;
 
 import com.pancake.api.content.domain.Content;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class ContentResponse {
 
@@ -16,8 +14,11 @@ public class ContentResponse {
     private String imageUrl;
     private boolean watched;
 
-    public static ContentResponse fromEntity(Content content) {
-        return new ContentResponse(content.getId(), content.getTitle(), content.getDescription(),
-                content.getImageUrl(), content.isWatched());
+    public ContentResponse(Content content) {
+        this.id = content.getId();
+        this.title = content.getTitle();
+        this.description = content.getDescription();
+        this.imageUrl = content.getImageUrl();
+        this.watched = content.isWatched();
     }
 }

--- a/api/src/main/java/com/pancake/api/content/api/WatchableContentResponse.java
+++ b/api/src/main/java/com/pancake/api/content/api/WatchableContentResponse.java
@@ -2,14 +2,12 @@ package com.pancake.api.content.api;
 
 import com.pancake.api.content.domain.Content;
 import com.pancake.api.content.domain.Playback;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class WatchableContentResponse {
 
@@ -21,22 +19,28 @@ public class WatchableContentResponse {
 
     private List<PlaybackResponse> playbacks;
 
-    public static WatchableContentResponse fromEntity(Content content) {
-        final var playbackList = content.getPlaybacks().stream().map(PlaybackResponse::fromEntity).toList();
-        return new WatchableContentResponse(content.getId(), content.getTitle(),
-                content.getDescription(), content.getImageUrl(), content.isWatched(),
-                playbackList);
+    public WatchableContentResponse(Content content) {
+        this.id = content.getId();
+        this.title = content.getTitle();
+        this.description = content.getDescription();
+        this.imageUrl = content.getImageUrl();
+        this.watched = content.isWatched();
+        this.playbacks = toPlaybacks(content.getPlaybacks());
+    }
+
+    private static List<PlaybackResponse> toPlaybacks(List<Playback> watchingOptions) {
+        return watchingOptions.stream().map(PlaybackResponse::new).toList();
     }
 
     @Data
-    @AllArgsConstructor
     @NoArgsConstructor
     public static class PlaybackResponse {
         private Long id;
-        private String platformName; // TODO: label로 바꿔라
+        private String platformLabel;
 
-        public static PlaybackResponse fromEntity(Playback playback) {
-            return new PlaybackResponse(playback.getId(), playback.getPlatform().label());
+        public PlaybackResponse(Playback playback) {
+            this.id = playback.getId();
+            this.platformLabel = playback.getPlatform().label();
         }
     }
 }

--- a/api/src/main/java/com/pancake/api/content/api/WatchableContentResponse.java
+++ b/api/src/main/java/com/pancake/api/content/api/WatchableContentResponse.java
@@ -33,10 +33,10 @@ public class WatchableContentResponse {
     @NoArgsConstructor
     public static class PlaybackResponse {
         private Long id;
-        private String platformName;
+        private String platformName; // TODO: label로 바꿔라
 
         public static PlaybackResponse fromEntity(Playback playback) {
-            return new PlaybackResponse(playback.getId(), "넷플릭스"); // TODO
+            return new PlaybackResponse(playback.getId(), playback.getPlatform().label());
         }
     }
 }

--- a/api/src/main/java/com/pancake/api/content/application/AddPlayback.java
+++ b/api/src/main/java/com/pancake/api/content/application/AddPlayback.java
@@ -1,0 +1,29 @@
+package com.pancake.api.content.application;
+
+import com.pancake.api.content.domain.Playback;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AddPlayback {
+
+    private final ContentService contentService;
+
+    private final PlatformMapper platformMapper;
+
+    @Transactional
+    public void with(long contentId, AddPlaybackCommand command) {
+        final var content = contentService.getBy(contentId);
+        final var watchOption = toWatchOption(command);
+
+        content.add(watchOption);
+    }
+
+    private Playback toWatchOption(AddPlaybackCommand command) {
+        final var platform = platformMapper.mapFrom(command);
+
+        return new Playback(command.getUrl(), platform);
+    }
+}

--- a/api/src/main/java/com/pancake/api/content/application/AddPlaybackCommand.java
+++ b/api/src/main/java/com/pancake/api/content/application/AddPlaybackCommand.java
@@ -1,7 +1,5 @@
 package com.pancake.api.content.application;
 
-import com.pancake.api.content.domain.Playback;
-import com.pancake.api.content.domain.PlaybackUrl;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,9 +10,4 @@ import lombok.NoArgsConstructor;
 public class AddPlaybackCommand {
 
     private String url;
-
-    public Playback toEntity() {
-        final var playbackUrl = new PlaybackUrl(getUrl());
-        return new Playback(playbackUrl);
-    }
 }

--- a/api/src/main/java/com/pancake/api/content/application/ContentService.java
+++ b/api/src/main/java/com/pancake/api/content/application/ContentService.java
@@ -1,11 +1,11 @@
 package com.pancake.api.content.application;
 
-import com.pancake.api.content.domain.Content;
-import com.pancake.api.content.domain.ContentRepository;
+import com.pancake.api.content.domain.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -33,7 +33,19 @@ public class ContentService {
     @Transactional
     public void addPlayback(long id, AddPlaybackCommand command) {
         final var content = loadContentBy(id);
-        content.add(command.toEntity());
+        final var playback = toPlayback(command);
+        content.add(playback);
+    }
+
+    private Playback toPlayback(AddPlaybackCommand command) {
+        final var platform = mapPlatformWith(command);
+        return new Playback(new PlaybackUrl(command.getUrl()), platform);
+    }
+
+    private Platform mapPlatformWith(AddPlaybackCommand command) {
+        return Arrays.stream(Platform.values())
+                .filter(e -> command.getUrl().startsWith(e.baseUrl()))
+                .findAny().orElseThrow(IllegalArgumentException::new);
     }
 
     private Content loadContentBy(long id) {

--- a/api/src/main/java/com/pancake/api/content/application/ContentService.java
+++ b/api/src/main/java/com/pancake/api/content/application/ContentService.java
@@ -1,11 +1,11 @@
 package com.pancake.api.content.application;
 
-import com.pancake.api.content.domain.*;
+import com.pancake.api.content.domain.Content;
+import com.pancake.api.content.domain.ContentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -26,30 +26,11 @@ public class ContentService {
 
     @Transactional
     public void watch(long id) {
-        final var content = loadContentBy(id);
+        final var content = getBy(id);
         content.watch();
     }
 
-    @Transactional
-    public void addPlayback(long id, AddPlaybackCommand command) {
-        final var content = loadContentBy(id);
-        final var playback = toPlayback(command);
-        content.add(playback);
-    }
-
-    private Playback toPlayback(AddPlaybackCommand command) {
-        final var platform = mapPlatformWith(command);
-        return new Playback(command.getUrl(), platform);
-    }
-
-    private Platform mapPlatformWith(AddPlaybackCommand command) {
-        final var url = new PlaybackUrl(command.getUrl());
-        return Arrays.stream(Platform.values())
-                .filter(url::isSatisfiedBy)
-                .findAny().orElseThrow(IllegalArgumentException::new);
-    }
-
-    private Content loadContentBy(long id) {
+    public Content getBy(long id) {
         return contentRepository.findById(id)
                 .orElseThrow(IllegalArgumentException::new);
     }

--- a/api/src/main/java/com/pancake/api/content/application/ContentService.java
+++ b/api/src/main/java/com/pancake/api/content/application/ContentService.java
@@ -1,6 +1,9 @@
 package com.pancake.api.content.application;
 
-import com.pancake.api.content.domain.*;
+import com.pancake.api.content.domain.Content;
+import com.pancake.api.content.domain.ContentRepository;
+import com.pancake.api.content.domain.Platform;
+import com.pancake.api.content.domain.Playback;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +42,7 @@ public class ContentService {
 
     private Playback toPlayback(AddPlaybackCommand command) {
         final var platform = mapPlatformWith(command);
-        return new Playback(new PlaybackUrl(command.getUrl()), platform);
+        return new Playback(command.getUrl(), platform);
     }
 
     private Platform mapPlatformWith(AddPlaybackCommand command) {

--- a/api/src/main/java/com/pancake/api/content/application/ContentService.java
+++ b/api/src/main/java/com/pancake/api/content/application/ContentService.java
@@ -1,9 +1,6 @@
 package com.pancake.api.content.application;
 
-import com.pancake.api.content.domain.Content;
-import com.pancake.api.content.domain.ContentRepository;
-import com.pancake.api.content.domain.Platform;
-import com.pancake.api.content.domain.Playback;
+import com.pancake.api.content.domain.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,8 +43,9 @@ public class ContentService {
     }
 
     private Platform mapPlatformWith(AddPlaybackCommand command) {
+        final var url = new PlaybackUrl(command.getUrl());
         return Arrays.stream(Platform.values())
-                .filter(e -> command.getUrl().startsWith(e.baseUrl()))
+                .filter(url::isSatisfiedBy)
                 .findAny().orElseThrow(IllegalArgumentException::new);
     }
 

--- a/api/src/main/java/com/pancake/api/content/application/PlatformMapper.java
+++ b/api/src/main/java/com/pancake/api/content/application/PlatformMapper.java
@@ -1,0 +1,28 @@
+package com.pancake.api.content.application;
+
+import com.pancake.api.content.domain.Platform;
+import com.pancake.api.content.domain.PlaybackUrl;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+@Component
+public class PlatformMapper {
+
+    public Platform mapFrom(AddPlaybackCommand command) {
+        return getPlatforms()
+                .filter(platform -> canMap(command, platform))
+                .findAny().orElseThrow(IllegalArgumentException::new);
+    }
+
+    private Stream<Platform> getPlatforms() {
+        return Arrays.stream(Platform.values());
+    }
+
+    private boolean canMap(AddPlaybackCommand command, Platform platform) {
+        final var url = new PlaybackUrl(command.getUrl());
+
+        return url.isSatisfiedBy(platform);
+    }
+}

--- a/api/src/main/java/com/pancake/api/content/domain/Platform.java
+++ b/api/src/main/java/com/pancake/api/content/domain/Platform.java
@@ -1,0 +1,22 @@
+package com.pancake.api.content.domain;
+
+public enum Platform {
+    NETFLIX("넷플릭스", "https://www.netflix.com/watch/"),
+    DISNEY_PLUS("디즈니플러스", "https://www.disneyplus.com/video/");
+
+    private final String label;
+    private final Url baseUrl;
+
+    Platform(String label, String baseUrl) {
+        this.label = label;
+        this.baseUrl = new Url(baseUrl);
+    }
+
+    public String label() {
+        return this.label;
+    }
+
+    public String baseUrl() {
+        return this.baseUrl.toString();
+    }
+}

--- a/api/src/main/java/com/pancake/api/content/domain/Playback.java
+++ b/api/src/main/java/com/pancake/api/content/domain/Playback.java
@@ -21,23 +21,23 @@ public class Playback {
     @Enumerated(EnumType.STRING)
     private Platform platform;
 
-    private PlaybackUrl playbackUrl;
+    private PlaybackUrl url;
 
-    public Playback(String playbackUrl, Platform platform) {
-        this(null, null, platform, new PlaybackUrl(playbackUrl));
+    public Playback(String url, Platform platform) {
+        this(null, null, platform, new PlaybackUrl(url));
     }
 
-    private Playback(Long id, Long contentId, Platform platform, PlaybackUrl playbackUrl) {
-        mustMatch(playbackUrl, platform);
+    private Playback(Long id, Long contentId, Platform platform, PlaybackUrl url) {
+        mustMatch(url, platform);
 
         this.id = id;
         this.contentId = contentId;
         this.platform = platform;
-        this.playbackUrl = playbackUrl;
+        this.url = url;
     }
 
-    private void mustMatch(PlaybackUrl playbackUrl, Platform platform) {
-        if (!playbackUrl.toString().startsWith(platform.baseUrl())) {
+    private void mustMatch(PlaybackUrl url, Platform platform) {
+        if (!url.isSatisfiedBy(platform)) {
             throw new IllegalArgumentException();
         }
     }
@@ -47,7 +47,7 @@ public class Playback {
     }
 
     public String getUrl() {
-        return this.playbackUrl.toString();
+        return this.url.toString();
     }
 
     public Platform getPlatform() {

--- a/api/src/main/java/com/pancake/api/content/domain/Playback.java
+++ b/api/src/main/java/com/pancake/api/content/domain/Playback.java
@@ -20,18 +20,25 @@ public class Playback {
     @Column(name = "content_id")
     private Long contentId;
 
+    @Enumerated(EnumType.STRING)
+    private Platform platform;
+
     private PlaybackUrl playbackUrl;
 
-    public Playback(PlaybackUrl playbackUrl) {
-        this(null, null, playbackUrl);
+    public Playback(PlaybackUrl playbackUrl, Platform platform) {
+        this(null, null, platform, playbackUrl);
     }
 
     public Long getId() {
         return this.id;
     }
 
-    public PlaybackUrl getUrl() {
-        return this.playbackUrl;
+    public String getUrl() {
+        return this.playbackUrl.toString();
+    }
+
+    public Platform getPlatform() {
+        return this.platform;
     }
 
     void setContent(Long contentId) {

--- a/api/src/main/java/com/pancake/api/content/domain/Playback.java
+++ b/api/src/main/java/com/pancake/api/content/domain/Playback.java
@@ -1,7 +1,6 @@
 package com.pancake.api.content.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -9,7 +8,6 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Entity
 @Table(name = "playbacks")
-@AllArgsConstructor
 @NoArgsConstructor(access = PRIVATE)
 public class Playback {
 
@@ -27,6 +25,21 @@ public class Playback {
 
     public Playback(String playbackUrl, Platform platform) {
         this(null, null, platform, new PlaybackUrl(playbackUrl));
+    }
+
+    private Playback(Long id, Long contentId, Platform platform, PlaybackUrl playbackUrl) {
+        mustMatch(playbackUrl, platform);
+
+        this.id = id;
+        this.contentId = contentId;
+        this.platform = platform;
+        this.playbackUrl = playbackUrl;
+    }
+
+    private void mustMatch(PlaybackUrl playbackUrl, Platform platform) {
+        if (!playbackUrl.toString().startsWith(platform.baseUrl())) {
+            throw new IllegalArgumentException();
+        }
     }
 
     public Long getId() {

--- a/api/src/main/java/com/pancake/api/content/domain/Playback.java
+++ b/api/src/main/java/com/pancake/api/content/domain/Playback.java
@@ -25,8 +25,8 @@ public class Playback {
 
     private PlaybackUrl playbackUrl;
 
-    public Playback(PlaybackUrl playbackUrl, Platform platform) {
-        this(null, null, platform, playbackUrl);
+    public Playback(String playbackUrl, Platform platform) {
+        this(null, null, platform, new PlaybackUrl(playbackUrl));
     }
 
     public Long getId() {

--- a/api/src/main/java/com/pancake/api/content/domain/PlaybackUrl.java
+++ b/api/src/main/java/com/pancake/api/content/domain/PlaybackUrl.java
@@ -13,11 +13,11 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Embeddable
 @NoArgsConstructor(access = PRIVATE)
-public final class PlaybackUrl {
+public final class Url {
 
     private URL url;
 
-    public PlaybackUrl(String value) {
+    public Url(String value) {
         if (value == null) {
             throw new IllegalArgumentException();
         }
@@ -30,9 +30,5 @@ public final class PlaybackUrl {
         } catch (MalformedURLException | URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
-    }
-
-    public String asString() {
-        return this.url.toString();
     }
 }

--- a/api/src/main/java/com/pancake/api/content/domain/PlaybackUrl.java
+++ b/api/src/main/java/com/pancake/api/content/domain/PlaybackUrl.java
@@ -13,7 +13,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Embeddable
 @NoArgsConstructor(access = PRIVATE)
-public final class PlaybackUrl {
+final class PlaybackUrl {
 
     private URL url;
 

--- a/api/src/main/java/com/pancake/api/content/domain/PlaybackUrl.java
+++ b/api/src/main/java/com/pancake/api/content/domain/PlaybackUrl.java
@@ -1,35 +1,25 @@
 package com.pancake.api.content.domain;
 
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 
 import static lombok.AccessLevel.PRIVATE;
 
 
 @Embeddable
 @NoArgsConstructor(access = PRIVATE)
-final class PlaybackUrl {
+@EqualsAndHashCode
+public final class PlaybackUrl {
 
-    private URL url;
+    private Url url;
 
-    public PlaybackUrl(String value) {
-        if (value == null) {
-            throw new IllegalArgumentException();
-        }
-        this.url = parse(value);
+    public PlaybackUrl(String url) {
+        this.url = new Url(url);
     }
 
-    private URL parse(String url) {
-        try {
-            return new URI(url).toURL();
-        } catch (MalformedURLException | URISyntaxException e) {
-            throw new IllegalArgumentException(e);
-        }
+    public boolean isSatisfiedBy(Platform platform) {
+        return this.url.toString().startsWith(platform.baseUrl());
     }
 
     @Override

--- a/api/src/main/java/com/pancake/api/content/domain/Url.java
+++ b/api/src/main/java/com/pancake/api/content/domain/Url.java
@@ -1,6 +1,8 @@
 package com.pancake.api.content.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.net.MalformedURLException;
@@ -13,27 +15,29 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Embeddable
 @NoArgsConstructor(access = PRIVATE)
-public final class PlaybackUrl {
+@EqualsAndHashCode
+final class Url {
 
-    private URL url;
+    @Column(name = "url")
+    private URL value;
 
-    public PlaybackUrl(String value) {
-        if (value == null) {
+    public Url(String url) {
+        if (url == null) {
             throw new IllegalArgumentException();
         }
-        this.url = parse(value);
+        this.value = parse(url);
     }
 
-    private URL parse(String url) {
+    private URL parse(String value) {
         try {
-            return new URI(url).toURL();
+            return new URI(value).toURL();
         } catch (MalformedURLException | URISyntaxException e) {
-            throw new IllegalArgumentException(e);
+            throw new IllegalArgumentException();
         }
     }
 
     @Override
     public String toString() {
-        return this.url.toString();
+        return this.value.toString();
     }
 }

--- a/api/src/main/java/com/pancake/api/watch/GetWatchApi.java
+++ b/api/src/main/java/com/pancake/api/watch/GetWatchApi.java
@@ -21,6 +21,6 @@ public class GetWatchApi {
     public ResponseEntity<Void> redirectToPUrl(@PathVariable Long id) {
         final var playback = loadPlayback.query(id);
 
-        return status(SEE_OTHER).location(URI.create(playback.getUrl().asString())).build();
+        return status(SEE_OTHER).location(URI.create(playback.getUrl())).build();
     }
 }

--- a/api/src/main/resources/db/migration/V20240208_2__Create_table_playbacks.sql
+++ b/api/src/main/resources/db/migration/V20240208_2__Create_table_playbacks.sql
@@ -1,6 +1,8 @@
 create table playbacks (
-    id              bigserial       primary key,
-    content_id      bigserial,
-    url    varchar(255)    not null,
+    id          bigserial       primary key,
+    content_id  bigserial,
+    platform    varchar(20),
+    url         varchar(255)    not null,
+
     foreign key (content_id) references contents(id)
 );

--- a/api/src/main/resources/db/migration/V20240208_3__Migration_content_has_multiple_url.sql
+++ b/api/src/main/resources/db/migration/V20240208_3__Migration_content_has_multiple_url.sql
@@ -2,5 +2,10 @@
 insert into playbacks (content_id, url)
 select id, url from contents;
 
+-- platform 컬럼 값이 없으므로 업데이트
+update playbacks
+set platform = 'NETFLIX'
+where platform is null;
+
 -- contents 테이블에서 url 컬럼 제거
 alter table contents drop column url;

--- a/api/src/test/java/com/pancake/api/AcceptanceTest.java
+++ b/api/src/test/java/com/pancake/api/AcceptanceTest.java
@@ -55,7 +55,7 @@ class AcceptanceTest {
         var playback = contents.stream()
                 .filter(e -> e.getId().equals(contentId))
                 .flatMap(e -> e.getPlaybacks().stream())
-                .filter(e -> e.getPlatformName().equals(platformName))
+                .filter(e -> e.getPlatformLabel().equals(platformName))
                 .findAny()
                 .orElseThrow();
 

--- a/api/src/test/java/com/pancake/api/AcceptanceTest.java
+++ b/api/src/test/java/com/pancake/api/AcceptanceTest.java
@@ -36,9 +36,10 @@ class AcceptanceTest {
     @Test
     void 사용자가_컨텐츠를_시청한다() {
         //준비
+        //준비
         var 원하는_컨텐츠 = 등록된_컨텐츠가_있다().getId();
+        컨텐츠에_시청주소를_추가한다(원하는_컨텐츠, "https://www.disneyplus.com/video/6e386dd6");
         컨텐츠에_시청주소를_추가한다(원하는_컨텐츠, "https://www.netflix.com/watch/70106454");
-        컨텐츠에_시청주소를_추가한다(원하는_컨텐츠, "https://www.disneyplus.com/ko-kr/video/6e386dd6");
         var 시청_아이디 = 시청할_컨텐츠의_플랫폼을_선택한다(조회된_컨텐츠_목록이_있다(), 원하는_컨텐츠, "넷플릭스");
 
         //목표

--- a/api/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
+++ b/api/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
@@ -1,5 +1,6 @@
 package com.pancake.api.content.api;
 
+import com.pancake.api.content.application.AddPlayback;
 import com.pancake.api.content.application.ContentService;
 import com.pancake.api.content.domain.Content;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,9 @@ class ContentApiControllerTest {
 
     @MockBean
     ContentService contentService;
+
+    @MockBean
+    AddPlayback addPlayback;
 
     @Autowired
     WebTestClient client;

--- a/api/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
+++ b/api/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
@@ -45,7 +45,7 @@ class ContentApiControllerTest {
         //then
         response.expectAll(
                 spec -> spec.expectStatus().isCreated(),
-                spec -> spec.expectBody(ContentResponse.class).isEqualTo(ContentResponse.fromEntity(content))
+                spec -> spec.expectBody(ContentResponse.class).isEqualTo(new ContentResponse(content))
         );
     }
 
@@ -104,6 +104,6 @@ class ContentApiControllerTest {
     }
 
     private WatchableContentResponse toResponse(Content content) {
-        return WatchableContentResponse.fromEntity(content);
+        return new WatchableContentResponse(content);
     }
 }

--- a/api/src/test/java/com/pancake/api/content/application/Builders.java
+++ b/api/src/test/java/com/pancake/api/content/application/Builders.java
@@ -1,6 +1,10 @@
 package com.pancake.api.content.application;
 
+import com.pancake.api.content.domain.Platform;
+import com.pancake.api.content.domain.Playback;
 import lombok.Builder;
+
+import static com.pancake.api.content.domain.Platform.NETFLIX;
 
 public abstract class Builders {
 
@@ -16,6 +20,12 @@ public abstract class Builders {
                 .url("https://www.netflix.com/watch/100000001");
     }
 
+    public static PlaybackBuilder aPlayback() {
+        return playbackBuilder()
+                .url("https://www.netflix.com/watch/100000001")
+                .platform(NETFLIX);
+    }
+
     @Builder(builderMethodName = "saveContentCommandBuilder")
     private static SaveContentCommand create(String title, String description, String imageUrl) {
         return new SaveContentCommand(title, description, imageUrl);
@@ -24,5 +34,10 @@ public abstract class Builders {
     @Builder(builderMethodName = "addPlaybackCommandBuilder")
     private static AddPlaybackCommand create(String url) {
         return new AddPlaybackCommand(url);
+    }
+
+    @Builder(builderMethodName = "playbackBuilder")
+    private static Playback create(String url, Platform platform) {
+        return new Playback(url, platform);
     }
 }

--- a/api/src/test/java/com/pancake/api/content/application/ContentApplicationTest.java
+++ b/api/src/test/java/com/pancake/api/content/application/ContentApplicationTest.java
@@ -29,6 +29,10 @@ class ContentApplicationTest {
     @Autowired
     ContentService contentService;
 
+    @Autowired
+    AddPlayback addPlayback;
+
+
     @AfterEach
     void cleanUp(@Autowired Flyway flyway) {
         flyway.clean();
@@ -82,11 +86,11 @@ class ContentApplicationTest {
         var contentId = savedContent().getId();
 
         //when
-        contentService.addPlayback(
+        addPlayback.with(
                 contentId,
                 aPlaybackToAdd().url("https://www.netflix.com/watch/0").build()
         );
-        contentService.addPlayback(
+        addPlayback.with(
                 contentId,
                 aPlaybackToAdd().url("https://www.disneyplus.com/video/1").build()
         );
@@ -112,7 +116,7 @@ class ContentApplicationTest {
 
     private void watchableContent(SaveContentCommandBuilder content, Builders.AddPlaybackCommandBuilder playback) {
         var contentId = savedContent(content).getId();
-        contentService.addPlayback(contentId, playback.build());
+        addPlayback.with(contentId, playback.build());
     }
 
     private Content savedContent() {

--- a/api/src/test/java/com/pancake/api/content/application/ContentApplicationTest.java
+++ b/api/src/test/java/com/pancake/api/content/application/ContentApplicationTest.java
@@ -3,6 +3,7 @@ package com.pancake.api.content.application;
 import com.pancake.api.content.application.Builders.SaveContentCommandBuilder;
 import com.pancake.api.content.domain.Content;
 import com.pancake.api.content.domain.ContentRepository;
+import com.pancake.api.content.domain.Platform;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.ObjectAssert;
 import org.flywaydb.core.Flyway;
@@ -40,7 +41,9 @@ class ContentApplicationTest {
         //given
         savedContent(aContentToSave().title("스파이더맨"));
         savedContent(aContentToSave().title("아이언맨"));
-        watchableContent(aContentToSave().title("토르"), aPlaybackToAdd());
+        watchableContent(
+                aContentToSave().title("토르"),
+                aPlaybackToAdd().url("https://www.netflix.com/watch/100000001"));
 
         //when
         var actual = contentService.getAllContents();
@@ -48,7 +51,8 @@ class ContentApplicationTest {
         //then
         assertThat(actual).singleElement()
                 .is(title("토르"))
-                .is(watchable());
+                .is(watchable())
+                .has(platform(Platform.NETFLIX));
     }
 
     @DisplayName("컨텐츠를 저장한다")
@@ -84,7 +88,7 @@ class ContentApplicationTest {
         );
         contentService.addPlayback(
                 contentId,
-                aPlaybackToAdd().url("https://www.disneyplus.com/ko-kr/video/1").build()
+                aPlaybackToAdd().url("https://www.disneyplus.com/video/1").build()
         );
 
         //then
@@ -143,5 +147,10 @@ class ContentApplicationTest {
 
     private Condition<Content> watched() {
         return new Condition<>(Content::isWatched, "isWatched is true");
+    }
+
+    private Condition<Content> platform(Platform expected) {
+        return new Condition<>(e -> e.getPlaybacks().stream().anyMatch(p -> p.getPlatform().equals(expected)),
+                "has expected platform");
     }
 }

--- a/api/src/test/java/com/pancake/api/content/application/ContentServiceTest.java
+++ b/api/src/test/java/com/pancake/api/content/application/ContentServiceTest.java
@@ -3,27 +3,25 @@ package com.pancake.api.content.application;
 import com.pancake.api.content.domain.Content;
 import com.pancake.api.content.domain.ContentRepository;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
 
-import static com.pancake.api.content.application.Builders.aPlaybackToAdd;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("NonAsciiCharacters")
 class ContentServiceTest {
 
     private final ContentRepository contentRepository = mock(ContentRepository.class);
     private final ContentService contentService = new ContentService(contentRepository);
 
-    @DisplayName("컨텐츠 목록 조회 시 시청할 수 없는 컨텐츠는 제외된다")
     @Test
-    void getAllContentsExcludesUnwatchableContent() {
+    void 목록_조회_시_시청할_수_없는_컨텐츠는_제외된다() {
         //given
         var content = mock(Content.class);
         given(content.canWatch()).willReturn(false, true, true);
@@ -36,22 +34,8 @@ class ContentServiceTest {
         assertThat(actual).hasSize(2);
     }
 
-    @DisplayName("존재하지 않는 컨텐츠에 시청 주소 추가 시 예외가 발생한다")
     @Test
-    void addWatchThrownExceptionWhenContentNotExist() {
-        //given
-        given(contentRepository.findById(anyLong())).willReturn(Optional.empty());
-
-        //when
-        ThrowingCallable actual = () -> contentService.addPlayback(anyLong(), aPlaybackToAdd().build());
-
-        //then
-        assertThatThrownBy(actual).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @DisplayName("존재하지 않는 컨텐츠를 시청 처리 시 예외가 발생한다")
-    @Test
-    void watchThrownExceptionWhenContentNotExist() {
+    void 존재하지_않는_컨텐츠를_시청_처리_시_예외가_발생한다() {
         //given
         given(contentRepository.findById(anyLong())).willReturn(Optional.empty());
 

--- a/api/src/test/java/com/pancake/api/content/application/PlatformMapperTest.java
+++ b/api/src/test/java/com/pancake/api/content/application/PlatformMapperTest.java
@@ -1,0 +1,58 @@
+package com.pancake.api.content.application;
+
+import com.pancake.api.content.domain.Platform;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.pancake.api.content.application.Builders.aPlaybackToAdd;
+import static com.pancake.api.content.domain.Platform.DISNEY_PLUS;
+import static com.pancake.api.content.domain.Platform.NETFLIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+class PlatformMapperTest {
+
+    private final PlatformMapper mapper = new PlatformMapper();
+
+    @Test
+    void 스트리밍_정보를_플랫폼으로_매핑할_수_없으면_예외를_던진다() {
+        //given
+        var streaming = create("https://invalid.some.site/view/1");
+
+        //when
+        ThrowingCallable actual = () -> mapper.mapFrom(streaming);
+
+        //then
+        assertThatThrownBy(actual).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideGivenAndExpected")
+    void 스트리밍_정보로_플랫폼을_매핑한다(String given, Platform expected) {
+        //given
+        var streaming = create(given);
+
+        //when
+        var actual = mapper.mapFrom(streaming);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideGivenAndExpected() {
+        return Stream.of(
+                Arguments.of("https://www.netflix.com/watch/1", NETFLIX),
+                Arguments.of("https://www.disneyplus.com/video/1", DISNEY_PLUS)
+        );
+    }
+
+    private static AddPlaybackCommand create(String url) {
+        return aPlaybackToAdd().url(url).build();
+    }
+}

--- a/api/src/test/java/com/pancake/api/content/domain/ContentTest.java
+++ b/api/src/test/java/com/pancake/api/content/domain/ContentTest.java
@@ -76,6 +76,6 @@ class ContentTest {
     private Playback createPlayback() {
         var playbackUrl = new PlaybackUrl("https://www.netflix.com/watch/999");
 
-        return new Playback(playbackUrl);
+        return new Playback(playbackUrl, Platform.NETFLIX);
     }
 }

--- a/api/src/test/java/com/pancake/api/content/domain/ContentTest.java
+++ b/api/src/test/java/com/pancake/api/content/domain/ContentTest.java
@@ -3,6 +3,7 @@ package com.pancake.api.content.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.pancake.api.content.application.Builders.aPlayback;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ContentTest {
@@ -35,7 +36,7 @@ class ContentTest {
     void addUrl() {
         //given
         var content = createContent();
-        var playback = createPlayback();
+        var playback = aPlayback().build();
 
         //when
         content.add(playback);
@@ -51,7 +52,7 @@ class ContentTest {
     void canWatchIsTrue() {
         //given
         var content = createContent();
-        content.add(createPlayback());
+        content.add(aPlayback().build());
 
         //when
         var actual = content.canWatch();
@@ -71,11 +72,5 @@ class ContentTest {
 
     private Content createContent() {
         return new Content("테스트용 제목", "테스트용 설명", "https://occ.nflxso.net/api/0");
-    }
-
-    private Playback createPlayback() {
-        var playbackUrl = new PlaybackUrl("https://www.netflix.com/watch/999");
-
-        return new Playback(playbackUrl, Platform.NETFLIX);
     }
 }

--- a/api/src/test/java/com/pancake/api/content/domain/PlatformTest.java
+++ b/api/src/test/java/com/pancake/api/content/domain/PlatformTest.java
@@ -1,0 +1,16 @@
+package com.pancake.api.content.domain;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("NonAsciiCharacters")
+class PlatformTest {
+
+    @ParameterizedTest
+    @EnumSource
+    void 기본주소는_슬래시로_끝난다(Platform platform) {
+        assertThat(platform.baseUrl()).endsWith("/");
+    }
+}

--- a/api/src/test/java/com/pancake/api/content/domain/PlaybackTest.java
+++ b/api/src/test/java/com/pancake/api/content/domain/PlaybackTest.java
@@ -1,0 +1,17 @@
+package com.pancake.api.content.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static com.pancake.api.content.domain.Platform.DISNEY_PLUS;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+class PlaybackTest {
+
+    @Test
+    void 생성_시_시청주소와_플랫폼이_일치하지_않으면_예외를_던진다() {
+        assertThatThrownBy(() -> new Playback("https://www.netflix.com/watch/1", DISNEY_PLUS))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/api/src/test/java/com/pancake/api/content/domain/PlaybackUrlTest.java
+++ b/api/src/test/java/com/pancake/api/content/domain/PlaybackUrlTest.java
@@ -1,48 +1,49 @@
 package com.pancake.api.content.domain;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.pancake.api.content.domain.Platform.DISNEY_PLUS;
+import static com.pancake.api.content.domain.Platform.NETFLIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class PlaybackUrlTest {
 
-    @DisplayName("주소가 비어있는 경우 예외를 던진다")
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = " ")
-    void createThrownExceptionWhenEmptyString(String url) {
-        //then
-        assertThatThrownBy(() -> create(url))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @DisplayName("주소에 공백이 포함된 경우 예외를 던진다")
     @Test
-    void createThrowExceptionWhenHasSpace() {
+    void isSatisfiedBy() {
         //given
-        var url = "https://www.netflix.com/watch/ 0000000";
+        var url = create("https://www.netflix.com/watch/1");
 
         //then
-        assertThatThrownBy(() -> create(url))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertAll(
+                () -> assertThat(url.isSatisfiedBy(NETFLIX)).isTrue(),
+                () -> assertThat(url.isSatisfiedBy(DISNEY_PLUS)).isFalse()
+        );
     }
 
-    @DisplayName("상대 주소인 경우 예외를 던진다")
     @Test
-    void createThrowExceptionWhenRelativeUrl() {
+    void equality() {
         //given
-        var url = "/watch/0000000";
+        var url = create("https://www.disneyplus.com/video/1");
+        var same = create("https://www.disneyplus.com/video/1");
+        var different = create("https://www.disneyplus.com/video/2");
 
         //then
-        assertThatThrownBy(() -> create(url))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(url)
+                .isEqualTo(same).hasSameHashCodeAs(same)
+                .isNotEqualTo(different).doesNotHaveSameHashCodeAs(different);
     }
 
-    private PlaybackUrl create(String value) {
-        return new PlaybackUrl(value);
+    @Test
+    void hasToString() {
+        //given
+        var url = create("https://www.disneyplus.com/video/1");
+
+        //then
+        assertThat(url).hasToString("https://www.disneyplus.com/video/1");
+    }
+
+    private PlaybackUrl create(String url) {
+        return new PlaybackUrl(url);
     }
 }

--- a/api/src/test/java/com/pancake/api/content/domain/UrlTest.java
+++ b/api/src/test/java/com/pancake/api/content/domain/UrlTest.java
@@ -1,0 +1,69 @@
+package com.pancake.api.content.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+class UrlTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = " ")
+    void 생성_시_주소가_빈_값이면_예외를_던진다(String given) {
+        assertThatThrownBy(() -> create(given)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            " https://www.netflix.com/watch/0000000",
+            "https://www.netflix.com/watch/0000000 ",
+            "https://www.netflix.com/watch/ 0000000",
+    })
+    void 생성_시_주소에_공백이_있으면_예외를_던진다() {
+        //given
+        var given = "https://www.netflix.com/watch/ 0000000";
+
+        //then
+        assertThatThrownBy(() -> create(given)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 생성_시_상대_주소이면_예외를_던진다() {
+        //given
+        var given = "/watch/0000000";
+
+        //then
+        assertThatThrownBy(() -> create(given)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void equality() {
+        //given
+        var url = create("https://www.disneyplus.com/video/1");
+        var same = create("https://www.disneyplus.com/video/1");
+        var different = create("https://www.disneyplus.com/video/2");
+
+        //then
+        assertThat(url)
+                .isEqualTo(same).hasSameHashCodeAs(same)
+                .isNotEqualTo(different).doesNotHaveSameHashCodeAs(different);
+    }
+
+    @Test
+    void hasToString() {
+        //given
+        var url = create("https://www.disneyplus.com/video/1");
+
+        //then
+        assertThat(url).hasToString("https://www.disneyplus.com/video/1");
+    }
+
+    private Url create(String value) {
+        return new Url(value);
+    }
+}

--- a/api/src/test/java/com/pancake/api/watch/GetWatchApiTest.java
+++ b/api/src/test/java/com/pancake/api/watch/GetWatchApiTest.java
@@ -1,5 +1,6 @@
 package com.pancake.api.watch;
 
+import com.pancake.api.content.domain.Platform;
 import com.pancake.api.content.domain.Playback;
 import com.pancake.api.content.domain.PlaybackUrl;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,8 @@ class GetWatchApiTest {
     @Test
     void redirectToPlaybackUrl() {
         //given
-        given(loadPlayback.query(anyLong())).willReturn(playback("https://www.netflix.com/watch/123"));
+        var playback = playback();
+        given(loadPlayback.query(anyLong())).willReturn(playback);
 
         //when
         var response = client.get().uri("/api/watch/{id}", anyLong()).exchange();
@@ -31,14 +33,14 @@ class GetWatchApiTest {
         //then
         response.expectAll(
                 spec -> spec.expectStatus().isSeeOther(),
-                spec -> spec.expectHeader().location("https://www.netflix.com/watch/123"),
+                spec -> spec.expectHeader().location(playback.getUrl()),
                 spec -> spec.expectBody(Void.class)
         );
     }
 
-    private Playback playback(String url) {
-        final var playbackUrl = new PlaybackUrl(url);
+    private Playback playback() {
+        final var playbackUrl = new PlaybackUrl("https://www.netflix.com/watch/123");
 
-        return new Playback(playbackUrl);
+        return new Playback(playbackUrl, Platform.NETFLIX);
     }
 }

--- a/api/src/test/java/com/pancake/api/watch/GetWatchApiTest.java
+++ b/api/src/test/java/com/pancake/api/watch/GetWatchApiTest.java
@@ -1,14 +1,12 @@
 package com.pancake.api.watch;
 
-import com.pancake.api.content.domain.Platform;
-import com.pancake.api.content.domain.Playback;
-import com.pancake.api.content.domain.PlaybackUrl;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import static com.pancake.api.content.application.Builders.aPlayback;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
@@ -24,7 +22,7 @@ class GetWatchApiTest {
     @Test
     void redirectToPlaybackUrl() {
         //given
-        var playback = playback();
+        var playback = aPlayback().build();
         given(loadPlayback.query(anyLong())).willReturn(playback);
 
         //when
@@ -36,11 +34,5 @@ class GetWatchApiTest {
                 spec -> spec.expectHeader().location(playback.getUrl()),
                 spec -> spec.expectBody(Void.class)
         );
-    }
-
-    private Playback playback() {
-        final var playbackUrl = new PlaybackUrl("https://www.netflix.com/watch/123");
-
-        return new Playback(playbackUrl, Platform.NETFLIX);
     }
 }


### PR DESCRIPTION
## 목표

기존에  하드코딩을 사용하여 가짜로 성공시킨 기능을 실제로 동작하도록 변경한다

```java
        public static PlaybackResponse fromEntity(Playback playback) {
            return new PlaybackResponse(playback.getId(), "넷플릭스"); // TODO
```

<br>

## 고민했던 것
```
www.netflix.com/watch/1 -> 넷플릭스
```
- `재생주소`를 사용해 `플랫폼`을 결정하는 역할의 책임은 누가?
  - 이 정보를 누가 알고 있어야 될 지 고민해봤음
  - 처음엔 `재생`, `재생주소`, `플랫폼`이 적당해 보였는데
  - 이 책임은 생성, 결정 두 가지가 합쳐졌다고 느껴졌고
  - 무엇보다 Platform의 한글명, 기본 재생 주소, 화면 순서 등의 관련 데이터를 enum vs DB  table vs 외부 설정 파일 중 어디에 저장할지 고민중이며 미래에 필요에 따라 변경할 의향이 있어서
  - `Mapper`가 `플랫폼`을 반환하여 내부적으로 platforms()를 얻는 방법 및 `재생주소`를 사용해야 한다는 지식을 알고있고
  - `재생주소`는 `플랫폼` 해당 여부를 반환하여 내부적으로 어떤 방식으로 비교하는지 구현을 알고있게 나눴음

## 변경 사항

### 사소한
- 서비스에서 재생주소 추가 기능을 분리
  - 플랫폼 매핑 기능은 해당 기능에서만 필요한데 `ContentService.class`에 있으면 불필요하게 커지는 것 같아서
- DTO 생성 시 new를 사용하도록 변경
  - toEntity()는 이름이 너무 엔티티라는 걸 명시하는 것 같고
  - 무엇보다 속성이 많아질 수록 `this(...)` 코드가 길어져 라인을 나누기 애매함을 느꼈음
  - 그러다 짱영호님 예제를 찾아봤는데 좋아보여서 따라함

<br>

## 남은 일

- 패키지가 너무 큼. 패키지 사용 주체로 생각해보니 3개로 나눠야 할 듯
- 엔티티 매핑을 1:N에서 N:1로 바꾸거나 해야 함