### PR TITLE
:lipstick: ui: 컨텐츠 편집 시 제목을 복사 가능하게 변경한다

### DIFF
--- a/app/lib/content/admin_screen.dart
+++ b/app/lib/content/admin_screen.dart
@@ -41,7 +41,7 @@ class _AdminScreenState extends State<AdminScreen> {
     await showDialog<void>(
       context: context,
       builder: (_) => MySimpleDialog(
-        title: Text(content.title),
+        title: SelectableText(content.title),
         child: ContentEditSection(content: content),
       ),
     );


### PR DESCRIPTION
## 이유
이미지 변경할 때 영화 제목을 손수 타이핑 해야돼서 힘듦