### PR TITLE
💄ui: 컨텐츠 카드에서 이미지 에러 발생 시 대체 위젯을 보여지게 한다

### DIFF
--- a/app/lib/content/content_list_view_section.dart
+++ b/app/lib/content/content_list_view_section.dart
@@ -26,6 +26,7 @@ class ContentListViewSection extends StatelessWidget {
             maxCrossAxisExtent: 200,
             mainAxisSpacing: 15,
             crossAxisSpacing: 15,
+            // TODO: childAspectRatio - 원래는 이미지 비율과 같아야하지만 title 때문에 임의의 상수 계산해서 넣음
             childAspectRatio: 0.56,
           ),
           itemBuilder: (context, index) {

--- a/app/lib/content/content_list_view_section.dart
+++ b/app/lib/content/content_list_view_section.dart
@@ -55,6 +55,16 @@ class _ContentCard extends StatelessWidget {
         HoverSlideImageCard(
           onTap: () => onTap(content),
           image: NetworkImage(content.imageUrl), // TODO: widget or image
+          errorBuilder: (_, __, ___) {
+            return const ColoredBox(
+              color: Colors.redAccent,
+              child: Icon(
+                Icons.error_outline,
+                color: Colors.white,
+                size: 80,
+              ),
+            );
+          },
         ),
         Flexible(
           child: Text(

--- a/app/lib/home/views/catalog_section.dart
+++ b/app/lib/home/views/catalog_section.dart
@@ -90,12 +90,15 @@ class _ContentCard extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         HoverSlideImageCard(
-          onTap: () => onSelected(content),
           image: NetworkImage(content.imageUrl),
+          onTap: () => onSelected(content),
           overlayWidget: Padding(
             padding: const EdgeInsets.all(15.0),
             child: _WatchShortcutText(content.shortcutOption),
           ),
+          errorBuilder: (_, __, ___) {
+            return const Center(child: Text('이미지를 로드할 수 없음'));
+          },
         ),
         _ContentTitle(content.title),
       ],

--- a/app/lib/widgets/hover_slide_image_card.dart
+++ b/app/lib/widgets/hover_slide_image_card.dart
@@ -5,13 +5,15 @@ import 'package:flutter/material.dart';
 class HoverSlideImageCard extends StatefulWidget {
   const HoverSlideImageCard({
     Key? key,
-    required this.onTap,
     required this.image,
+    required this.onTap,
+    this.errorBuilder,
     this.overlayWidget,
   }) : super(key: key);
 
-  final GestureTapCallback onTap;
   final ImageProvider image;
+  final GestureTapCallback onTap;
+  final ImageErrorWidgetBuilder? errorBuilder;
   final Widget? overlayWidget;
 
   @override
@@ -71,9 +73,11 @@ class _HoverSlideImageCardState extends State<HoverSlideImageCard>
           child: Stack(
             alignment: Alignment.bottomLeft,
             children: [
-              _Image(
-                opacity: _opacityAnimation,
+              Image(
                 image: widget.image,
+                opacity: _opacityAnimation,
+                fit: BoxFit.cover,
+                errorBuilder: widget.errorBuilder,
               ),
               FadeTransition(
                 opacity: _controller.view,
@@ -129,22 +133,6 @@ class _Card extends StatelessWidget {
         margin: EdgeInsets.zero,
         child: child,
       ),
-    );
-  }
-}
-
-class _Image extends StatelessWidget {
-  const _Image({required this.opacity, required this.image});
-
-  final ImageProvider image;
-  final Animation<double> opacity;
-
-  @override
-  Widget build(BuildContext context) {
-    return Image(
-      image: image,
-      opacity: opacity,
-      fit: BoxFit.cover,
     );
   }
 }

--- a/app/lib/widgets/hover_slide_image_card.dart
+++ b/app/lib/widgets/hover_slide_image_card.dart
@@ -73,11 +73,14 @@ class _HoverSlideImageCardState extends State<HoverSlideImageCard>
           child: Stack(
             alignment: Alignment.bottomLeft,
             children: [
-              Image(
-                image: widget.image,
-                opacity: _opacityAnimation,
-                fit: BoxFit.cover,
-                errorBuilder: widget.errorBuilder,
+              AspectRatio(
+                aspectRatio: 2 / 3,
+                child: Image(
+                  image: widget.image,
+                  opacity: _opacityAnimation,
+                  fit: BoxFit.cover,
+                  errorBuilder: widget.errorBuilder,
+                ),
               ),
               FadeTransition(
                 opacity: _controller.view,


### PR DESCRIPTION
## 목표

현재 이미지 에러 발생 시 아무것도 보이지 않는 부분 개선

## 작업

- 전

<img width="774" alt="image" src="https://github.com/viiviii/friendly-pancake/assets/75404713/32611ccf-2d50-4068-837e-f10b6e298364">

- 후

<img width="789" alt="image" src="https://github.com/viiviii/friendly-pancake/assets/75404713/81da410b-4ff9-403e-97b2-ef38c2056afa">

(왼) 메인에서, (오) 나만 볼 때
