### PR TITLE
⬆️ dependencies: SpringBoot 버전을 3.2.5로 업그레이드 한다

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.5'
+    id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.0'
 }
 


### PR DESCRIPTION
## 이유

- 외부 API 호출을 위해 `RestClient`를 사용하기로 결정했음
- `RestClient`는 spring version 6.1부터 지원되나 현재 프로젝트의 버전은 6.0.7임
- 그래서 스프링부트를 현재 가장 최근 버전인 3.2.5로 업그레이드 한다
  - 그럼 스프링 버전은 6.1.6을 사용하게 됨

