### PR TITLE
👷 cicd: 배포 시 tmdb api token을 사용하도록 구성한다

### DIFF
--- a/.github/workflows/api-deployment.yml
+++ b/.github/workflows/api-deployment.yml
@@ -41,6 +41,7 @@ jobs:
         if: steps.current.outputs.id == null
         env:
           spring_datasource_properties: ${{ secrets.SPRING_DATASOURCE_PROPERTIES }}
+          tmdb_api_properties: ${{ secrets.TMDB_API_PROPERTIES }}
         run: docker compose up --wait --build --detach
 
       - name: '🚀 Deploy newly api service'
@@ -48,6 +49,7 @@ jobs:
         id: newly
         env:
           spring_datasource_properties: ${{ secrets.SPRING_DATASOURCE_PROPERTIES }}
+          tmdb_api_properties: ${{ secrets.TMDB_API_PROPERTIES }}
         run: docker compose up --wait --build --detach --remove-orphans --no-recreate --scale api=2 api
 
       - name: '🔄 Reload nginx'


### PR DESCRIPTION
## 작업

compose에만 추가해놔서 현재 배포 시 에러나는 것 수정함

<img width="883" alt="image" src="https://github.com/viiviii/friendly-pancake/assets/75404713/9272b7e6-691b-415c-99d3-b6597cdcd953">

---

### 선행 작업

- git secret에 추가
<img width="790" alt="image" src="https://github.com/viiviii/friendly-pancake/assets/75404713/68020b12-7787-4ebf-90a8-22e63150bfbf">

- compose 추가
https://github.com/viiviii/friendly-pancake/blob/3c399fdda4e1d2d0c6b669c446460e08c987952c/compose-service-api.yml#L1-L22