### PR TITLE
🔧 config: 테스트용 application.yml를 추가한다

### DIFF
--- a/api/config/README.md
+++ b/api/config/README.md
@@ -13,6 +13,10 @@ api.tmdb.token=$ACCESS_TOKEN
 spring.datasource.url=jdbc:postgresql://$HOST:$PORT/
 spring.datasource.username=$USER_NAME
 spring.datasource.password=$PASSWORD
+
+# [선택]
+# 로컬에서 테스트 시 해당 외부 구성을 사용하지 않기 위해서
+spring.config.activate.on-profile=default
 ```
 
 <br>

--- a/api/src/test/java/com/pancake/api/AcceptanceTest.java
+++ b/api/src/test/java/com/pancake/api/AcceptanceTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec.ResponseSpecConsumer;
@@ -31,7 +30,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-@TestPropertySource(properties = {"spring.flyway.clean-disabled=false", "api.tmdb.token=test-token"})
 @Import(MockTmdbServerConfiguration.class)
 @SuppressWarnings("NonAsciiCharacters")
 class AcceptanceTest {

--- a/api/src/test/java/com/pancake/api/ApplicationTest.java
+++ b/api/src/test/java/com/pancake/api/ApplicationTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
 
 import java.time.Instant;
 import java.util.List;
@@ -30,7 +29,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = NONE)
-@TestPropertySource(properties = {"spring.flyway.clean-disabled=false", "api.tmdb.token=test-token"})
 class ApplicationTest {
 
     @Autowired

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  profiles:
+    active: test
+  flyway:
+    clean-disabled: false
+
+api:
+  tmdb:
+    token: 'test-token' # 참고: 이 값을 비교하는 테스트가 존재함


### PR DESCRIPTION
## 작업

- 테스트에서 사용할 application.yml을 추가
- 테스트 환경에서 활성 프로필을 `test`로 설정

## 이유

- 테스트 실행 시 환경(로컬)에 구성된 외부 구성 파일을 제외할 수 있도록

## 왜

- 이전 작업(#116)에서 secret한 구성들은 외부 파일로 구성하도록 변경하였음
- 배포 환경에선 상관 없지만 로컬에서 개발 시 `직접 실행`, `테스트 실행` 2가지 사용 방식이 있음
- 현재 구조는 항상 로컬에서 구성한 외부 파일을 사용함
  -  i.e) 테스트에서 in-memory DB가 아닌 로컬에서 docker로 띄워둔 개발용 DB 사용
- 구성이 다음 순서로 적용되기 때문임

> 구성 파일 적용 순서
> https://docs.spring.io/spring-boot/docs/3.2.5/reference/html/features.html#features.external-config

<img width="856" alt="image" src="https://github.com/viiviii/friendly-pancake/assets/75404713/aab75635-7334-4e45-ab3d-0105f6262548">

## 개선 방안

### A. active 프로필을 지정하는 방법
예를 들어,
테스트에 활성 프로필을 `test`로 지정하고, 외부 구성 파일에는 활성 프로필이 `default`일 때만 해당 설정을 활성화하게 구성

반대로 메인에 활성 프로필을 지정하고, 외부 구성 파일을 해당 프로필로 작성하게 구성할 수도 있음

이 케이스의 장점은 해당 프로필의 파일이 없어도 오류가 발생하지 않으므로, 배포쪽 코드를 바꾸지 않아도 됨

### B. include 하는 방법

이 방법은 `include: secret`으로 설정한 경우 application-secret.yml이 꼭 존재해야 함

단점은 해당 파일이 존재하지 않으면 에러가 난다는 것이지만 이게 또 장점일 수도 있다고 생각.
그리고 빨리 에러가 나게 만들고 config 폴더의 내용들을 resource/로 옮겨서 관리하는 것도 좋다고 생각함.

## 결정

일단 (A) 방식으로 변경함. 
이유는 현재 상태에서 가장 쉽고 변경이 적게 적용할 수 있기 때문

