### PR TITLE
♻️ refactor: 컨텐츠의 metadata와 저장 DTO를 분리한다

### DIFF
--- a/api/src/main/java/com/pancake/api/content/api/ContentApiController.java
+++ b/api/src/main/java/com/pancake/api/content/api/ContentApiController.java
@@ -1,7 +1,7 @@
 package com.pancake.api.content.api;
 
 import com.pancake.api.content.application.AddPlayback;
-import com.pancake.api.content.application.ContentMetadata;
+import com.pancake.api.content.application.ContentSaveCommand;
 import com.pancake.api.content.application.ContentService;
 import com.pancake.api.content.application.ContentStreaming;
 import com.pancake.api.content.domain.ContentRepository;
@@ -33,8 +33,8 @@ public class ContentApiController {
     }
 
     @PostMapping
-    public ResponseEntity<ContentResponse> save(@RequestBody ContentMetadata metadata) {
-        final var content = contentService.save(metadata);
+    public ResponseEntity<ContentResponse> save(@RequestBody ContentSaveCommand command) {
+        final var content = contentService.save(command);
         final var response = new ContentResponse(content);
 
         return status(CREATED).body(response);

--- a/api/src/main/java/com/pancake/api/content/application/ContentMetadata.java
+++ b/api/src/main/java/com/pancake/api/content/application/ContentMetadata.java
@@ -1,6 +1,5 @@
 package com.pancake.api.content.application;
 
-import com.pancake.api.content.domain.Content;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,8 +18,4 @@ public class ContentMetadata {
     private String description;
     private String imageUrl;
     private LocalDate releaseDate;
-
-    public Content toContent() {
-        return new Content(title, description, imageUrl);
-    }
 }

--- a/api/src/main/java/com/pancake/api/content/application/ContentSaveCommand.java
+++ b/api/src/main/java/com/pancake/api/content/application/ContentSaveCommand.java
@@ -1,0 +1,12 @@
+package com.pancake.api.content.application;
+
+import com.pancake.api.content.domain.Content;
+import lombok.Builder;
+
+@Builder
+public record ContentSaveCommand(String title, String imageUrl, String description) {
+
+    public Content toContent() {
+        return new Content(title, description, imageUrl);
+    }
+}

--- a/api/src/main/java/com/pancake/api/content/application/ContentService.java
+++ b/api/src/main/java/com/pancake/api/content/application/ContentService.java
@@ -12,8 +12,8 @@ public class ContentService {
 
     private final ContentRepository contentRepository;
 
-    public Content save(ContentMetadata metadata) {
-        return contentRepository.save(metadata.toContent());
+    public Content save(ContentSaveCommand command) {
+        return contentRepository.save(command.toContent());
     }
 
     public Content get(long id) {

--- a/api/src/test/java/com/pancake/api/AcceptanceTest.java
+++ b/api/src/test/java/com/pancake/api/AcceptanceTest.java
@@ -3,6 +3,7 @@ package com.pancake.api;
 import com.pancake.api.bookmark.BookmarkResponse;
 import com.pancake.api.bookmark.Builders.BookmarkSaveCommandBuilder;
 import com.pancake.api.content.api.ContentResponse;
+import com.pancake.api.content.application.ContentSaveCommand.ContentSaveCommandBuilder;
 import com.pancake.api.content.domain.Playback;
 import com.pancake.api.search.SearchContentMetadata;
 import com.pancake.api.setting.api.SettingApiController.PlatformSettingResponse;
@@ -90,7 +91,7 @@ class AcceptanceTest {
     @Test
     void 나는_컨텐츠를_관리할_수_있다() {
         //준비
-        컨텐츠를_등록한다().apply(aMetadata());
+        컨텐츠를_등록한다().apply(aContentSaveCommand());
 
         //목표
         var 컨텐츠_목록 = 컨텐츠_목록을_조회한다();
@@ -146,7 +147,7 @@ class AcceptanceTest {
                 .returnResult().getResponseBody();
     }
 
-    private Function<ContentMetadataBuilder, ContentResponse> 컨텐츠를_등록한다() {
+    private Function<ContentSaveCommandBuilder, ContentResponse> 컨텐츠를_등록한다() {
         return builder -> client.post().uri("/api/contents")
                 .contentType(APPLICATION_JSON)
                 .bodyValue(builder.build())
@@ -227,7 +228,7 @@ class AcceptanceTest {
     }
 
     private void 컨텐츠를_등록하고(Consumer<ContentResponse> fn) {
-        var response = 컨텐츠를_등록한다().apply(aMetadata());
+        var response = 컨텐츠를_등록한다().apply(aContentSaveCommand());
 
         fn.accept(response);
     }

--- a/api/src/test/java/com/pancake/api/ApplicationTest.java
+++ b/api/src/test/java/com/pancake/api/ApplicationTest.java
@@ -5,6 +5,7 @@ import com.pancake.api.bookmark.BookmarkService;
 import com.pancake.api.bookmark.Builders.BookmarkSaveCommandBuilder;
 import com.pancake.api.content.Builders;
 import com.pancake.api.content.application.AddPlayback;
+import com.pancake.api.content.application.ContentSaveCommand;
 import com.pancake.api.content.application.ContentService;
 import com.pancake.api.content.domain.Content;
 import com.pancake.api.content.domain.Playback;
@@ -25,8 +26,7 @@ import java.time.Instant;
 import java.util.List;
 
 import static com.pancake.api.bookmark.Builders.aBookmarkSaveCommand;
-import static com.pancake.api.content.Builders.aMetadata;
-import static com.pancake.api.content.Builders.aStreaming;
+import static com.pancake.api.content.Builders.*;
 import static com.pancake.api.content.domain.Platform.NETFLIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
@@ -108,14 +108,14 @@ class ApplicationTest {
         @Test
         void 컨텐츠의_메타데이터를_저장한다() {
             //given
-            var metadata = aMetadata()
+            var command = aContentSaveCommand()
                     .title("토토로")
                     .description("설명")
                     .imageUrl("http://some.image")
                     .build();
 
             //when
-            var content = contentService.save(metadata);
+            var content = contentService.save(command);
 
             //then
             assertThat(actualBy(content.getId(), Content.class))
@@ -127,7 +127,7 @@ class ApplicationTest {
         @Test
         void 컨텐츠에_시청주소를_추가한다() {
             //given
-            var contentId = save(aMetadata());
+            var contentId = save(aContentSaveCommand());
 
             //when
             addPlayback.command(
@@ -149,7 +149,7 @@ class ApplicationTest {
         @Test
         void 컨텐츠를_시청_처리한다() {
             //given
-            var contentId = save(aMetadata());
+            var contentId = save(aContentSaveCommand());
 
             //when
             contentService.watch(contentId);
@@ -162,7 +162,7 @@ class ApplicationTest {
         @Test
         void 컨텐츠의_이미지를_변경한다() {
             //given
-            var contentId = save(aMetadata().imageUrl("원래 이미지 주소"));
+            var contentId = save(aContentSaveCommand().imageUrl("원래 이미지 주소"));
 
             //when
             contentService.changeImage(contentId, "바뀐 이미지 주소");
@@ -185,7 +185,7 @@ class ApplicationTest {
         @Test
         void 시청주소를_조회한다() {
             //given
-            var contentId = save(aMetadata());
+            var contentId = save(aContentSaveCommand());
             add(contentId, aStreaming().url("https://www.netflix.com/watch/100000001"));
 
             //when
@@ -198,8 +198,8 @@ class ApplicationTest {
         @Test
         void 시청할_컨텐츠_목록을_조회한다() {
             //given
-            save(aMetadata().title("스파이더맨"));
-            add(save(aMetadata().title("토르")), aStreaming());
+            save(aContentSaveCommand().title("스파이더맨"));
+            add(save(aContentSaveCommand().title("토르")), aStreaming());
 
             //when
             var actual = getContentsToWatch.query();
@@ -231,7 +231,7 @@ class ApplicationTest {
         }
     }
 
-    private Long save(Builders.ContentMetadataBuilder builder) {
+    private Long save(ContentSaveCommand.ContentSaveCommandBuilder builder) {
         return contentService.save(builder.build()).getId();
     }
 

--- a/api/src/test/java/com/pancake/api/content/Builders.java
+++ b/api/src/test/java/com/pancake/api/content/Builders.java
@@ -1,6 +1,7 @@
 package com.pancake.api.content;
 
 import com.pancake.api.content.application.ContentMetadata;
+import com.pancake.api.content.application.ContentSaveCommand;
 import com.pancake.api.content.application.ContentStreaming;
 import com.pancake.api.content.domain.Platform;
 import com.pancake.api.content.domain.Playback;
@@ -20,8 +21,10 @@ public abstract class Builders {
                 .id("99999")
                 .contentType("movie")
                 .title("테스트용 제목")
+                .originalTitle("테스트용 원제목")
                 .description("테스트용 설명")
-                .imageUrl("테스트용 이미지 주소");
+                .imageUrl("테스트용 이미지 주소")
+                .releaseDate(LocalDate.of(2099, 12, 31));
     }
 
     public static ContentStreamingBuilder aStreaming() {
@@ -59,9 +62,16 @@ public abstract class Builders {
                 .voteCount(7599);
     }
 
+    public static ContentSaveCommand.ContentSaveCommandBuilder aContentSaveCommand() {
+        return ContentSaveCommand.builder()
+                .title("테스트용 제목")
+                .description("테스트용 설명")
+                .imageUrl("테스트용 이미지 주소");
+    }
+
     @Builder(builderMethodName = "contentMetadata")
-    private static ContentMetadata create(String id, String contentType, String title, String description, String imageUrl) {
-        return new ContentMetadata(id, contentType, title, "original title", description, imageUrl, LocalDate.of(2099, 12, 31));
+    private static ContentMetadata create(String id, String contentType, String title, String originalTitle, String description, String imageUrl, LocalDate releaseDate) {
+        return new ContentMetadata(id, contentType, title, originalTitle, description, imageUrl, releaseDate);
     }
 
     @Builder(builderMethodName = "contentStreaming")

--- a/api/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
+++ b/api/src/test/java/com/pancake/api/content/api/ContentApiControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import static com.pancake.api.content.Builders.aMetadata;
+import static com.pancake.api.content.Builders.aContentSaveCommand;
 import static com.pancake.api.content.Builders.aStreaming;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -32,7 +32,7 @@ class ContentApiControllerTest {
     @Test
     void saveContent() {
         //given
-        var request = aMetadata().build();
+        var request = aContentSaveCommand().build();
         var content = request.toContent();
 
         given(contentService.save(request)).willReturn(content);

--- a/api/src/test/java/com/pancake/api/content/infra/persistence/JpaContentRepositoryTest.java
+++ b/api/src/test/java/com/pancake/api/content/infra/persistence/JpaContentRepositoryTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-import static com.pancake.api.content.Builders.aMetadata;
+import static com.pancake.api.content.Builders.aContentSaveCommand;
 import static com.pancake.api.content.Builders.aPlayback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -55,6 +55,6 @@ class JpaContentRepositoryTest {
     }
 
     private Content content() {
-        return aMetadata().build().toContent();
+        return aContentSaveCommand().build().toContent();
     }
 }

--- a/api/src/test/java/com/pancake/api/watch/infra/JpaContentQueryRepositoryTest.java
+++ b/api/src/test/java/com/pancake/api/watch/infra/JpaContentQueryRepositoryTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-import static com.pancake.api.content.Builders.aMetadata;
+import static com.pancake.api.content.Builders.aContentSaveCommand;
 import static com.pancake.api.content.Builders.aPlayback;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -62,7 +62,7 @@ class JpaContentQueryRepositoryTest {
     }
 
     private Content contentWith(Builders.PlaybackBuilder playback) {
-        var content = aMetadata().build().toContent();
+        var content = aContentSaveCommand().build().toContent();
         content.add(playback.build());
 
         return content;

--- a/api/src/test/java/com/pancake/api/watch/infra/JpaPlaybackQueryRepositoryTest.java
+++ b/api/src/test/java/com/pancake/api/watch/infra/JpaPlaybackQueryRepositoryTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-import static com.pancake.api.content.Builders.aMetadata;
+import static com.pancake.api.content.Builders.aContentSaveCommand;
 import static com.pancake.api.content.Builders.aPlayback;
 import static com.pancake.api.content.domain.Platform.NETFLIX;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,7 +64,7 @@ class JpaPlaybackQueryRepositoryTest {
     }
 
     private Content contentWith(Builders.PlaybackBuilder playback) {
-        var content = aMetadata().build().toContent();
+        var content = aContentSaveCommand().build().toContent();
         content.add(playback.build());
 
         return content;


### PR DESCRIPTION
이유: 하나로 저장, 결과를 담당하고 metadata를 사용하는 곳이 많아져 복잡해졌길래